### PR TITLE
FIX: usage of data with different x and y dimensions

### DIFF
--- a/preRegistration/get_xyFOVs.m
+++ b/preRegistration/get_xyFOVs.m
@@ -9,7 +9,7 @@ ny = floor(Ly/iR(1));
 nx = floor(Lx/iR(2));
 
 xFOVs = zeros(nx, iR(2), iR(1));
-yFOVs = zeros(nx, iR(2), iR(1));
+yFOVs = zeros(ny, iR(2), iR(1));
 for i = 1:iR(1)
     for j = 1:iR(2)
         xFOVs(:,j,i) = [1:nx] + (j-1)*nx;


### PR DESCRIPTION
If input data had different x and y dimensions a dimension mismatch
occurred. This was due to a small typo fixed in this commit.