### PR TITLE
fix for saving RegBinFiles correctly

### DIFF
--- a/nonRigidRegistration/blockReg2P.m
+++ b/nonRigidRegistration/blockReg2P.m
@@ -182,6 +182,7 @@ for i = 1:numPlanes
     
     if ~isempty(ops.RegFileTiffLocation)
         ops1{i} = write_reg_to_tiff(fid{i}, ops1{i}, i);
+        frewind(fid{i});
     end    
     if ~isempty(ops.RegFileBinLocation)
         folder = fullfile(ops1{i}.RegFileBinLocation, ops1{i}.mouse_name, ...

--- a/registration/reg2P.m
+++ b/registration/reg2P.m
@@ -183,9 +183,11 @@ for i = 1:numPlanes
     
     if ~isempty(ops.RegFileTiffLocation)
         ops1{i} = write_reg_to_tiff(fid{i}, ops1{i}, i);
+        frewind(fid{i});
     end    
     if ~isempty(ops.nimgbegend) && ops.nimgbegend>0
         ops1{i} = getBlockBegEnd(fid{i}, ops1{i}); % get mean of first and last frames in block (to check for drift)
+        frewind(fid{i});
     end
     if ~isempty(ops.RegFileBinLocation)
         str = sprintf('%d_',ops1{i}.expts);


### PR DESCRIPTION
Changes in reg2P and blockReg2p:
rewind the file identifiers for the registered .bin files 
after write_reg_to_tiff or getBlockBegEnd.  Otherwise, if
you need to save a copy of the .bin files to another HDD
( i.e. if ~iesmpty(ops.RegFileBinLocation)) you will write
empty .bin copies to disk.