### PR TITLE
Register dense zstack

### DIFF
--- a/preRegistration/GetRandFrames.m
+++ b/preRegistration/GetRandFrames.m
@@ -7,15 +7,17 @@ nchannels          = getOr(ops, {'nchannels'}, 1);
 ichannel           = getOr(ops, {'gchannel'}, 1);
 rchannel           = getOr(ops, {'rchannel'}, 2);
 red_align          = getOr(ops, {'AlignToRedChannel'}, 0);
-
+targetImage        = getOr(ops, {'targetImage'}, []); % if not empty, 
+% generate target image from specified experiment (useful if there is slow
+% drift in data)
 ntifs = sum(cellfun(@(x) numel(x), fs));
 nfmax = max(1, round(ops.NimgFirstRegistration/ntifs));
 if nfmax>=2000
     nfmax = 1999;
 end
 nbytes = fs{1}(1).bytes;
-nFr = nFrames(fs{1}(1).name);
 Info0 = imfinfo(fs{1}(1).name);
+nFr = length(Info0);
 Ly = Info0(1).Height;
 Lx = Info0(1).Width;
 ops.Lx = Lx;
@@ -24,46 +26,83 @@ ops.Ly = Ly;
 indx = 0;
 IMG = zeros(Ly, Lx, nplanes, ops.NimgFirstRegistration, 'single');
 
-for k = 1:length(ops.SubDirs)
-    iplane0 = 1;
-    for j = 1:length(fs{k})
+if ~isempty(targetImage)
+    k = targetImage(1);
+    if abs(nbytes - fs{k}(1).bytes)>1e3
+        nbytes = fs{k}(1).bytes;
+        nFr = nFrames(fs{k}(1).name);
+    end
+    startTiff = floor(length(fs{k})/2 - ...
+        nplanes*nchannels*ops.NimgFirstRegistration/2/nFr);
+    iplane = mod(((startTiff-1)*nFr)/nchannels-1, nplanes) + 1;
+    j = startTiff;
+    while indx < ops.NimgFirstRegistration
+        offset = 0;
+        if j == 1
+            offset = nchannels*nplanes;
+        end
         if abs(nbytes - fs{k}(j).bytes)>1e3
             nbytes = fs{k}(j).bytes;
             nFr = nFrames(fs{k}(j).name);
         end
-        if j==1
-            offset = nchannels*nplanes;
-        else
-            offset = 0;
-        end
-        
-        if nFr<(nchannels*nplanes*nfmax+offset)
-            continue;
-        end
-        
-        iplane0 = mod(iplane0-1, nplanes) + 1;
-        
+        numFr = min(ops.NimgFirstRegistration-indx, nFr/nchannels/nplanes);
         if red_align
-            ichanset = [offset + nchannels*(iplane0-1) + [rchannel;...
-                nchannels*nplanes*nfmax]; nchannels];
+            ichanset = [offset + nchannels*(nplanes-iplane) + [rchannel;...
+                nchannels*nplanes*numFr]; nchannels];
         else
-            ichanset = [offset + nchannels*(iplane0-1) + [ichannel;...
-                nchannels*nplanes*nfmax]; nchannels];
+            ichanset = [offset + nchannels*(nplanes-iplane) + [ichannel;...
+                nchannels*nplanes*numFr]; nchannels];
         end
-        iplane0 = iplane0 - nFr/nchannels;
-        data = loadFramesBuff(fs{k}(j).name, ichanset(1),ichanset(2), ichanset(3));
+        iplane = mod(iplane + nFr/nchannels - 1, nplanes) + 1;
+        data = loadFramesBuff(fs{k}(j).name, ichanset(1), ichanset(2), ichanset(3));
         data = reshape(data, Ly, Lx, nplanes, []);
-       
+        
         IMG(:,:,:,indx+(1:size(data,4))) = data;
         indx = indx + size(data,4);
-       
-        if indx>ops.NimgFirstRegistration
-           break; 
-        end
+        j = j + 1;
     end
-    
-    if indx>ops.NimgFirstRegistration
-           break; 
+else
+    for k = 1:length(ops.SubDirs)
+        iplane0 = 1;
+        for j = 1:length(fs{k})
+            if abs(nbytes - fs{k}(j).bytes)>1e3
+                nbytes = fs{k}(j).bytes;
+                nFr = nFrames(fs{k}(j).name);
+            end
+            if j==1
+                offset = nchannels*nplanes;
+            else
+                offset = 0;
+            end
+            
+            if nFr<(nchannels*nplanes*nfmax+offset)
+                continue;
+            end
+            
+            iplane0 = mod(iplane0-1, nplanes) + 1;
+            
+            if red_align
+                ichanset = [offset + nchannels*(iplane0-1) + [rchannel;...
+                    nchannels*nplanes*nfmax]; nchannels];
+            else
+                ichanset = [offset + nchannels*(iplane0-1) + [ichannel;...
+                    nchannels*nplanes*nfmax]; nchannels];
+            end
+            iplane0 = iplane0 - nFr/nchannels;
+            data = loadFramesBuff(fs{k}(j).name, ichanset(1),ichanset(2), ichanset(3));
+            data = reshape(data, Ly, Lx, nplanes, []);
+            
+            IMG(:,:,:,indx+(1:size(data,4))) = data;
+            indx = indx + size(data,4);
+            
+            if indx>ops.NimgFirstRegistration
+                break;
+            end
+        end
+        
+        if indx>ops.NimgFirstRegistration
+            break;
+        end
     end
 end
 IMG =  IMG(:,:,:,1:indx);

--- a/registration/GetRegOffsets.m
+++ b/registration/GetRegOffsets.m
@@ -1,15 +1,27 @@
-function [dsall, ops1] = GetRegOffsets(data, j, iplane0, ops, ops1, yFOVs, xFOVs)
+function [dsall, ops1] = GetRegOffsets(data, k, j, iplane0, ops, ops1)
+
+nplanes = getOr(ops, {'nplanes'}, 1);
+alignAcrossPlanes  = getOr(ops, {'alignAcrossPlanes'}, false);
+planesToInterpolate = getOr(ops, {'planesToInterpolate'}, 1:nplanes);
+% split into subsets (for high scanning resolution recordings)
+[xFOVs, yFOVs] = get_xyFOVs(ops);
 
 dsall = zeros(size(data,3), 2, size(xFOVs,2));
 for i = 1:numel(ops.planesToProcess)
-    ifr0 = iplane0(ops.planesToProcess(i));
-    indframes = ifr0:ops.nplanes:size(data,3);
+    if alignAcrossPlanes && ismember(i, planesToInterpolate) % load frames of all planes
+        indframes = 1:size(data,3);
+    else
+        ifr0 = iplane0(ops.planesToProcess(i));
+        indframes = ifr0:ops.nplanes:size(data,3);
+    end
     
     for l = 1:size(xFOVs,2)
         dat = data(yFOVs(:,l),xFOVs(:,l),indframes);
         if ~isempty(ops.smooth_time_space)
             dat = smooth_movie(dat, ops);
         end
+        % align all loaded frames to target image of current plane
+        % (get registration offsets)
         [ds, Corr]  = regoffKriging(dat, ops1{i,l}, 0);
         
         %ds          = RemoveBadShifts(ds);
@@ -21,6 +33,7 @@ for i = 1:numel(ops.planesToProcess)
         end
         ops1{i,l}.DS          = cat(1, ops1{i,l}.DS, ds);
         ops1{i,l}.CorrFrame   = cat(1, ops1{i,l}.CorrFrame, Corr);
+        ops1{i,l}.Nframes(k)  = ops1{i,l}.Nframes(k) + length(indframes);
     end
     
     1;

--- a/registration/PlotRegMean.m
+++ b/registration/PlotRegMean.m
@@ -1,12 +1,15 @@
 function PlotRegMean(ops1,ops)
 
 figure('position', [900 50 900 900])
-    ax = ceil(sqrt(numel(ops1)));
-    for i = 1:length(ops1)
-        subplot(ax,ax,i)
-        imagesc(ops1{i}.mimg)
-        colormap('gray')
-        title(sprintf('Registration for plane %d, mouse %s, date %s', ...
-            i, ops.mouse_name, ops.date))
-    end
-    drawnow
+ax = ceil(sqrt(numel(ops1)));
+for i = 1:length(ops1)
+    subplot(ax,ax,i)
+    imagesc(ops1{i}.mimg)
+    colormap('gray')
+    title(sprintf('Plane %d', i))
+end
+annotation('textbox', [0 .96 1 .03], 'String', ...
+    sprintf('Registration for mouse %s, date %s', ops.mouse_name, ops.date), ...
+    'Interpreter', 'none', 'FontWeight', 'bold', 'LineStyle', 'none', ...
+    'HorizontalAlignment', 'center');
+drawnow

--- a/registration/getOutliers.m
+++ b/registration/getOutliers.m
@@ -5,6 +5,11 @@ Corr = ops.CorrFrame;
 ops.nSDbadregCorr   = getOr(ops, 'nSDbadregCorr', 5);
 ops.nTbadregWindow  = getOr(ops, 'nTbadregWindow', 30);
 
+ind = isnan(Corr);
+x = 1:length(Corr);
+vq = interp1(x(~ind),Corr(~ind),x(ind),'pchip');
+Corr(ind) = vq;
+
 mCorr = medfilt1(Corr, ops.nTbadregWindow);
 
 lCorr = log(max(1e-6, Corr)) - log(max(1e-6, mCorr));

--- a/registration/redoRegistration.m
+++ b/registration/redoRegistration.m
@@ -1,10 +1,6 @@
-function redoRegistration(ops, ichannel)
+function redoRegistration(ops1, ichannel, iplanes)
 
 % Cannot be used with multiple FOVs, and ignores BiDiPhase
-
-alignAcrossPlanes  = getOr(ops, {'alignAcrossPlanes'}, false);
-interpolateAcrossPlanes = getOr(ops, {'interpolateAcrossPlanes'}, false);
-planesToInterpolate = getOr(ops, {'planesToInterpolate'}, 1:nplanes);
 
 if nargin < 2 || isempty(ichannel)
     if isfield(ops, 'gchannel') && ~isempty(ops.gchannel)
@@ -14,24 +10,25 @@ if nargin < 2 || isempty(ichannel)
     end
 end
 
-fs = ops.fsroot;
-nchannels = ops.nchannels;
+fs = ops1{1}.fsroot;
+nchannels = ops1{1}.nchannels;
+nplanes = ops1{1}.nplanes;
 
-regdir = fileparts(ops.RegFile);
+regdir = fileparts(ops1{1}.RegFile);
 if ~exist(regdir, 'dir')
     mkdir(regdir);
 end
 
-splitBlocks    = getOr(ops, {'splitBlocks'}, 'none');
-Ly = ops.Ly;
-Lx = ops.Lx;
+splitBlocks    = getOr(ops1{1}, {'splitBlocks'}, 'none');
+Ly = ops1{1}.Ly;
+Lx = ops1{1}.Lx;
 if iscell(splitBlocks)
-    numBlocks = length(ops.yBL);
+    numBlocks = length(ops1{1}.yBL);
     xyMask = zeros(Ly, Lx, numBlocks, 'single');
     for i = 1:numBlocks
         msk = zeros(Ly, Lx, 'single');
-        msk(ops.yBL{i},ops.xBL{i}) = 1;
-        sT = ops.splitTaper;
+        msk(ops1{1}.yBL{i},ops1{1}.xBL{i}) = 1;
+        sT = ops1{1}.splitTaper;
         msk = my_conv(my_conv(msk, sT)',sT)';
         xyMask(:,:,i) = msk;
     end
@@ -40,55 +37,28 @@ if iscell(splitBlocks)
 end
 
 % open bin file for writing
-fid = fopen(ops.RegFile, 'w');
+fid = cell(1, length(iplanes));
+for i = 1:length(iplanes)
+    fid{i} = fopen(ops1{iplanes(i)}.RegFile, 'w');
+end
 
-iplane = ops.iplane;
-dsall = ops.DS;
-T = size(dsAll,1);
-Dims = size(dsAll,2);
-usedPlanes = [];
-if isfield(ops, 'alignedToPlanes')
-    if ops.planeInterpolated == 0
-        subscripts = cat(3, repmat((1:T)',1,Dims), ...
-            repmat(1:Dims,T,1), repmat(ops.alignedToPlanes,1,Dims));
-        subscripts = reshape(subscripts, [], 3);
-        linearInd = sub2ind(size(dsall), subscripts(:,1), subscripts(:,2), ...
-            subscripts(:,3));
-        values = dsall(linearInd);
-        values = reshape(values, T, Dims);
-        dsall = values;
-    else
-        usedPlanes = find(sum(ops.usedPlanes,1) > 0);
-        shifts = iplane - ops.basisPlanes;
-        ds = NaN(T*usedPlanes, Dims);
-        for i = 1:length(usedPlanes)
-            subscripts = cat(3, repmat((1:T)',1,Dims), ...
-                repmat(1:Dims,T,1), repmat(usedPlanes(i) + shifts,1,Dims));
-            subscripts = reshape(subscripts, [], 3);
-            subscripts(subscripts(:,3)<planesToInterpolate(1), 3) = ...
-                planesToInterpolate(1);
-            subscripts(subscripts(:,3)>planesToInterpolate(end), 3) = ...
-                planesToInterpolate(end);
-            linearInd = sub2ind(size(dsall), subscripts(:,1), subscripts(:,2), ...
-                subscripts(:,3));
-            values = dsall(linearInd);
-            values = reshape(values, T, Dims);
-            indframes = i:length(usedPlanes):(T*length(usedPlanes));
-            ds(indframes,:) = values;
-        end
-        dsall = ds;
+dsall = NaN(size(ops1{1}.DS,1), 2, nplanes);
+for i = 1:nplanes
+    t = 0;
+    for k = 1:length(ops1{i}.Nframes)
+        dsall(t + (1:ops1{i}.Nframes(k)),:,i) = ...
+            ops1{i}.DS(sum(ops1{i}.Nframes(1:k-1)) + (1:ops1{i}.Nframes(k)),:);
+        t = t + ops1{1}.Nframes(k);
     end
 end
+dsall = reshape(permute(dsall, [3 1 2]), [], 2);
 
 t2 = 0;
 % if two consecutive files have as many bytes, they have as many frames
 nbytes = 0;
 for k = 1:length(fs)
-    ds = dsall(sum(ops.Nframes((1:length(fs))<k))*max(1,length(usedPlanes)) + ...
-        (1:ops.Nframes(k)),:);
-%     ds = ds(iplane0:ops.nplanes:end,:);
-    dataPrev = zeros(ops.Ly, ops.Lx, nplanes, 'int16');
-    iplane0 = 1:1:ops.nplanes;
+    dataPrev = zeros(Ly, Lx, nplanes, 'int16');
+    iplane0 = 1:1:nplanes;
     t1 = 0;
     for j = 1:length(fs{k})
         if abs(nbytes - fs{k}(j).bytes)>1e3
@@ -97,24 +67,10 @@ for k = 1:length(fs)
         end
         iplane0 = mod(iplane0-1, nplanes) + 1;
         
-        if isempty(usedPlanes)
-            ichanset = [iplane0(iplane); nFr; nchannels*ops.nplanes];
-        else
-            ichanset = [ichannel; nFr; nchannels];
-        end
+        ichanset = [ichannel; nFr; nchannels];
         data = loadFramesBuff(fs{k}(j).name, ichanset(1), ichanset(2), ...
             ichanset(3));
-        if ~isempty(usedPlanes)
-            [~,a] = sort(iplane0(usedPlanes));
-            planes = repmat(usedPlanes(a)', 1, ceil(size(data,3)/nplanes));
-            planes = planes(:);
-            ind = bsxfun(@plus, iplane0(usedPlanes), ...
-                (0:nplanes:ceil(size(data,3)/nplanes)));
-            ind = ind(:);
-            planes(ind>size(data,3)) = [];
-            ind(ind>size(data,3)) = [];
-            data = data(:,:,ind);
-        end
+        
         ix0 = 0;
         Nbatch = 1000;
         dreg = zeros(size(data), class(data));
@@ -123,62 +79,66 @@ for k = 1:length(fs)
             indxr(indxr>size(data,3)) = [];
             if iscell(splitBlocks)
                 dreg(:, :, indxr) = blockRegisterMovie(data(:, :, indxr), ...
-                    xyMask, ds(t1 + indxr,:,:));
+                    xyMask, dsall(t1+t2 + indxr,:,:));
             else
                 dreg(:, :, indxr)        = ...
-                    register_movie(data(:, :, indxr), ops, ds(t1 + indxr,:));
+                    register_movie(data(:, :, indxr), ops1{1}, dsall(t1+t2 + indxr,:));
             end
             ix0 = ix0 + Nbatch;
         end
-        if ~isempty(usedPlanes)
-            ind1 = find(planes == iplane);
-            bases = ops.basisPlanes(ceil((t2+t1)/length(usedPlanes) + ...
-                (1:length(ind1))));
-            uniqueBases = unique(bases);
-            dwrite = zeros(size(dreg,1), size(dreg,2), length(ind1));
-            dataNext = [];
-            for b = uniqueBases
-                planesInv = find(~isnan(ops.profiles(:,b)))';
-                diffs = planesInv - iplane;
-                for pl = 1:length(planesInv)
-                    ind2 = ind1 + diffs(pl);
-                    ind2(bases ~= b) = [];
-                    weight = ops.profiles(planesInv(pl),b);
-                    if ind2(1)<1 % frame is part of previously loaded tiff file (can happen if frames per tiff are not mupltiple of planes)
-                        dwrite(:,:,1) = dwrite(:,:,1) + ...
-                            weight .* double(dataPrev(:,:,end-ind2(1)));
-                        ind2(1) = [];
-                    end
-                    if ind2(end)>size(dreg,3) % frame is part of upcoming tiff file
-                        if j<length(fs{k})
-                            if isempty(dataNext) % load first few frames of next tiff and register them
-                                ichanset = [ichannel; nplanes; ops.nchannels];
-                                data = loadFramesBuff(fs{k}(j+1).name, ichanset(1), ichanset(2), ichanset(3));
-                                iplane1 = iplane0 - nFr/nchannels;
-                                iplane1 = mod(iplane1-1, nplanes) + 1;
-                                data = data(:,:,iplane1(usedPlanes));
-                                dataNext = register_movie(data, ops, ...
-                                    ds(t1+t2+length(planes)+ (1:length(usedPlanes)),:));
-                            end
-                            dwrite(:,:,end) = dwrite(:,:,end) + weight .*...
-                                double(dataNext(:,:,ind2(end)-size(dreg,3)));
+        
+        dataNext = [];
+        for i = 1:length(iplanes)
+            if isfield(ops1{iplanes(i)}, 'planeInterpolated') && ...
+                    ops1{iplanes(i)}.planeInterpolated == 1
+                ind1 = iplane0(iplanes(i)) : nplanes : size(data,3);
+                bases = ops1{iplanes(i)}.basisPlanes(ceil((t2+t1)/nplanes + ...
+                    (1:length(ind1))));
+                uniqueBases = unique(bases)';
+                dwrite = zeros(size(dreg,1), size(dreg,2), length(ind1));
+                for b = uniqueBases
+                    planesInv = find(~isnan(ops1{iplanes(i)}.profiles(:,b)) & ...
+                        ops1{iplanes(i)}.profiles(:,b)>0)';
+                    diffs = planesInv - iplanes(i);
+                    for pl = 1:length(planesInv)
+                        ind2 = ind1 + diffs(pl);
+                        ind2(bases ~= b) = [];
+                        weight = ops1{iplanes(i)}.profiles(planesInv(pl),b);
+                        if ind2(1)<1 % frame is part of previously loaded tiff file (can happen if frames per tiff are not mupltiple of planes)
+                            dwrite(:,:,1) = dwrite(:,:,1) + ...
+                                weight .* double(dataPrev(:,:,end-ind2(1)));
+                            ind2(1) = [];
                         end
-                        ind2(end) = [];
+                        if ind2(end)>size(dreg,3) % frame is part of upcoming tiff file
+                            if j<length(fs{k})
+                                if isempty(dataNext) % load first few frames of next tiff and register them
+                                    ichanset = [ichannel; nplanes; nchannels];
+                                    data = loadFramesBuff(fs{k}(j+1).name, ...
+                                        ichanset(1), ichanset(2), ichanset(3));
+                                    dataNext = register_movie(data, ops1{iplanes(i)}, ...
+                                        dsall(t1+t2+size(dreg,3)+ (1:nplanes),:));
+                                end
+                                dwrite(:,:,end) = dwrite(:,:,end) + weight .*...
+                                    double(dataNext(:,:,ind2(end)-size(dreg,3)));
+                            end
+                            ind2(end) = [];
+                        end
+                        dwrite(:,:,ceil(ind2/nplanes)) = dwrite(:,:,ceil(ind2/nplanes)) + ...
+                            weight .* double(dreg(:,:,ind2));
                     end
-                    dwrite(:,:,ceil(ind2/length(usedPlanes))) = dwrite(:,:,ceil(ind2/length(usedPlanes))) + ...
-                        weight .* double(dreg(:,:,ind2));
                 end
+                fwrite(fid{i}, dwrite, class(data));
+            else
+                fwrite(fid{i}, dreg, class(data));
             end
-            dataPrev = dreg(:,:,end-length(usedPlanes)+1:end);
-            fwrite(fid, dwrite, class(data));
-            t1 = t1 + length(planes);
-        else
-            fwrite(fid, dreg, class(data));
-            t1 = t1 + size(data,3);
         end
+        dataPrev = dreg(:,:,end-nplanes+1:end);
+        t1 = t1 + size(dreg,3);
         iplane0 = iplane0 - nFr/nchannels;
     end
-    t2 = t2 + ops.Nframes(k)*length(usedPlanes);
+    t2 = t2 + ceil(t1/nplanes)*nplanes;
 end
 
-fclose(fid);
+for i = 1:length(iplanes)
+    fclose(fid{i});
+end

--- a/registration/redoRegistration.m
+++ b/registration/redoRegistration.m
@@ -1,9 +1,16 @@
 function redoRegistration(ops, ichannel)
 
+% Cannot be used with multiple FOVs, and ignores BiDiPhase
+
+alignAcrossPlanes  = getOr(ops, {'alignAcrossPlanes'}, false);
+interpolateAcrossPlanes = getOr(ops, {'interpolateAcrossPlanes'}, false);
+planesToInterpolate = getOr(ops, {'planesToInterpolate'}, 1:nplanes);
+
 if nargin < 2 || isempty(ichannel)
     if isfield(ops, 'gchannel') && ~isempty(ops.gchannel)
         ichannel = ops.gchannel;
-    else ichannel = 1;
+    else
+        ichannel = 1;
     end
 end
 
@@ -35,22 +42,79 @@ end
 % open bin file for writing
 fid = fopen(ops.RegFile, 'w');
 
-iplane0 = ops.iplane;
+iplane = ops.iplane;
 dsall = ops.DS;
+T = size(dsAll,1);
+Dims = size(dsAll,2);
+usedPlanes = [];
+if isfield(ops, 'alignedToPlanes')
+    if ops.planeInterpolated == 0
+        subscripts = cat(3, repmat((1:T)',1,Dims), ...
+            repmat(1:Dims,T,1), repmat(ops.alignedToPlanes,1,Dims));
+        subscripts = reshape(subscripts, [], 3);
+        linearInd = sub2ind(size(dsall), subscripts(:,1), subscripts(:,2), ...
+            subscripts(:,3));
+        values = dsall(linearInd);
+        values = reshape(values, T, Dims);
+        dsall = values;
+    else
+        usedPlanes = find(sum(ops.usedPlanes,1) > 0);
+        shifts = iplane - ops.basisPlanes;
+        ds = NaN(T*usedPlanes, Dims);
+        for i = 1:length(usedPlanes)
+            subscripts = cat(3, repmat((1:T)',1,Dims), ...
+                repmat(1:Dims,T,1), repmat(usedPlanes(i) + shifts,1,Dims));
+            subscripts = reshape(subscripts, [], 3);
+            subscripts(subscripts(:,3)<planesToInterpolate(1), 3) = ...
+                planesToInterpolate(1);
+            subscripts(subscripts(:,3)>planesToInterpolate(end), 3) = ...
+                planesToInterpolate(end);
+            linearInd = sub2ind(size(dsall), subscripts(:,1), subscripts(:,2), ...
+                subscripts(:,3));
+            values = dsall(linearInd);
+            values = reshape(values, T, Dims);
+            indframes = i:length(usedPlanes):(T*length(usedPlanes));
+            ds(indframes,:) = values;
+        end
+        dsall = ds;
+    end
+end
+
+t2 = 0;
+% if two consecutive files have as many bytes, they have as many frames
+nbytes = 0;
 for k = 1:length(fs)
-    ds = dsall(sum(ops.Nframes((1:length(fs))<k)) + (1:ops.Nframes(k)),:,:);
+    ds = dsall(sum(ops.Nframes((1:length(fs))<k))*max(1,length(usedPlanes)) + ...
+        (1:ops.Nframes(k)),:);
 %     ds = ds(iplane0:ops.nplanes:end,:);
-    frCount = 0;
-    frCount2 = 0;
+    dataPrev = zeros(ops.Ly, ops.Lx, nplanes, 'int16');
+    iplane0 = 1:1:ops.nplanes;
+    t1 = 0;
     for j = 1:length(fs{k})
-        nFr = nFrames(fs{k}(j).name);
-        frameGroups = mod(frCount+(1:nchannels*ops.nplanes), ...
-            nchannels*ops.nplanes);
-        frameGroups(frameGroups == 0) = nchannels*ops.nplanes;
-        firstFrame = find(frameGroups == nchannels*(iplane0-1)+ichannel);
-        ichanset = [firstFrame; nFr; nchannels*ops.nplanes];
+        if abs(nbytes - fs{k}(j).bytes)>1e3
+            nbytes = fs{k}(j).bytes;
+            nFr = nFramesTiff(fs{k}(j).name);
+        end
+        iplane0 = mod(iplane0-1, nplanes) + 1;
+        
+        if isempty(usedPlanes)
+            ichanset = [iplane0(iplane); nFr; nchannels*ops.nplanes];
+        else
+            ichanset = [ichannel; nFr; nchannels];
+        end
         data = loadFramesBuff(fs{k}(j).name, ichanset(1), ichanset(2), ...
             ichanset(3));
+        if ~isempty(usedPlanes)
+            [~,a] = sort(iplane0(usedPlanes));
+            planes = repmat(usedPlanes(a)', 1, ceil(size(data,3)/nplanes));
+            planes = planes(:);
+            ind = bsxfun(@plus, iplane0(usedPlanes), ...
+                (0:nplanes:ceil(size(data,3)/nplanes)));
+            ind = ind(:);
+            planes(ind>size(data,3)) = [];
+            ind(ind>size(data,3)) = [];
+            data = data(:,:,ind);
+        end
         ix0 = 0;
         Nbatch = 1000;
         dreg = zeros(size(data), class(data));
@@ -59,17 +123,62 @@ for k = 1:length(fs)
             indxr(indxr>size(data,3)) = [];
             if iscell(splitBlocks)
                 dreg(:, :, indxr) = blockRegisterMovie(data(:, :, indxr), ...
-                    xyMask, ds(frCount2 + indxr,:,:));
+                    xyMask, ds(t1 + indxr,:,:));
             else
                 dreg(:, :, indxr)        = ...
-                    register_movie(data(:, :, indxr), ops, ds(frCount2 + indxr,:));
+                    register_movie(data(:, :, indxr), ops, ds(t1 + indxr,:));
             end
             ix0 = ix0 + Nbatch;
         end
-        fwrite(fid, dreg, class(data));
-        frCount = frCount + nFr;
-        frCount2 = frCount2 + size(data,3);
+        if ~isempty(usedPlanes)
+            ind1 = find(planes == iplane);
+            bases = ops.basisPlanes(ceil((t2+t1)/length(usedPlanes) + ...
+                (1:length(ind1))));
+            uniqueBases = unique(bases);
+            dwrite = zeros(size(dreg,1), size(dreg,2), length(ind1));
+            dataNext = [];
+            for b = uniqueBases
+                planesInv = find(~isnan(ops.profiles(:,b)))';
+                diffs = planesInv - iplane;
+                for pl = 1:length(planesInv)
+                    ind2 = ind1 + diffs(pl);
+                    ind2(bases ~= b) = [];
+                    weight = ops.profiles(planesInv(pl),b);
+                    if ind2(1)<1 % frame is part of previously loaded tiff file (can happen if frames per tiff are not mupltiple of planes)
+                        dwrite(:,:,1) = dwrite(:,:,1) + ...
+                            weight .* double(dataPrev(:,:,end-ind2(1)));
+                        ind2(1) = [];
+                    end
+                    if ind2(end)>size(dreg,3) % frame is part of upcoming tiff file
+                        if j<length(fs{k})
+                            if isempty(dataNext) % load first few frames of next tiff and register them
+                                ichanset = [ichannel; nplanes; ops.nchannels];
+                                data = loadFramesBuff(fs{k}(j+1).name, ichanset(1), ichanset(2), ichanset(3));
+                                iplane1 = iplane0 - nFr/nchannels;
+                                iplane1 = mod(iplane1-1, nplanes) + 1;
+                                data = data(:,:,iplane1(usedPlanes));
+                                dataNext = register_movie(data, ops, ...
+                                    ds(t1+t2+length(planes)+ (1:length(usedPlanes)),:));
+                            end
+                            dwrite(:,:,end) = dwrite(:,:,end) + weight .*...
+                                double(dataNext(:,:,ind2(end)-size(dreg,3)));
+                        end
+                        ind2(end) = [];
+                    end
+                    dwrite(:,:,ceil(ind2/length(usedPlanes))) = dwrite(:,:,ceil(ind2/length(usedPlanes))) + ...
+                        weight .* double(dreg(:,:,ind2));
+                end
+            end
+            dataPrev = dreg(:,:,end-length(usedPlanes)+1:end);
+            fwrite(fid, dwrite, class(data));
+            t1 = t1 + length(planes);
+        else
+            fwrite(fid, dreg, class(data));
+            t1 = t1 + size(data,3);
+        end
+        iplane0 = iplane0 - nFr/nchannels;
     end
+    t2 = t2 + ops.Nframes(k)*length(usedPlanes);
 end
 
 fclose(fid);

--- a/registration/reg2P.m
+++ b/registration/reg2P.m
@@ -144,7 +144,8 @@ for i = 1:numPlanes
                 mkdir(folder);
             end
             fidIntpol{i,j} = fopen(fullfile(folder, ...
-                sprintf('plane%d.bin',i + (j-1)*numPlanes)), 'w');
+                sprintf('%s_%s_%s_plane%d.bin', ops.mouse_name, ops.date, ...
+                ops.CharSubDirs, i + (j-1)*numPlanes)));
         end
     end
 end
@@ -260,14 +261,14 @@ for i = 1:numel(ops1)
         frewind(fid{i});
     end
     if ~isempty(ops.RegFileBinLocation)
-        str = sprintf('%d_',ops1{i}.expts);
-        str(end) = [];
         folder = fullfile(ops1{i}.RegFileBinLocation, ops1{i}.mouse_name, ...
-            ops1{i}.date, str);
+            ops1{i}.date, ops.CharSubDirs);
         if ~exist(folder, 'dir')
             mkdir(folder)
         end
-        fidCopy = fopen(fullfile(folder, sprintf('plane%d.bin', i)), 'w');
+        fidCopy = fopen(fullfile(folder, ...
+            sprintf('%s_%s_%s_plane%d.bin', ops.mouse_name, ops.date, ...
+            ops.CharSubDirs, i)), 'w');
         sz = ops1{i}.Lx * ops1{i}.Ly;
         parts = ceil(sum(ops1{i}.Nframes) / 2000);
         for p = 1:parts
@@ -284,9 +285,10 @@ for i = 1:numel(ops1)
         if ops.interpolateAcrossPlanes == 1 && ~isempty(RegFileBinLocation)
             fclose(fidIntpol{i});
             folder = fullfile(ops1{i}.RegFileBinLocation, ops1{i}.mouse_name, ...
-                ops1{i}.date, str, 'interpolated');
+                ops1{i}.date, ops.CharSubDirs, 'interpolated');
             filename = fullfile(folder, ...
-                sprintf('plane%d.bin',ops.planesToProcess(i)));
+                sprintf('%s_%s_%s_plane%d.bin', ops.mouse_name, ops.date, ...
+                ops.CharSubDirs, i));
             if ismember(i, planesToInterp)
                 fidCopy = fopen(ops1{i}.RegFile, 'w');
                 fidOrig = fopen(filename, 'r');

--- a/registration/registerAcrossPlanes.m
+++ b/registration/registerAcrossPlanes.m
@@ -1,0 +1,310 @@
+function [ops1, planesToInterp] = registerAcrossPlanes(ops1, ops, fid, fidIntpol)
+
+nplanes = getOr(ops, {'nplanes'}, 1);
+planesToInterpolate = getOr(ops, {'planesToInterpolate'}, 1:nplanes);
+ichannel = getOr(ops, {'gchannel'}, 1);
+BiDiPhase = getOr(ops, {'BiDiPhase'}, 0);
+RegFileBinLocation = getOr(ops, {'RegFileBinLocation'}, []);
+interpolateAcrossPlanes = getOr(ops, {'interpolateAcrossPlanes'}, false);
+fs = ops.fsroot;
+[xFOVs, yFOVs] = get_xyFOVs(ops);
+
+% in order to determine optimal shifts in z at each time point, collect 
+% registration offsets and correlations of all frames with all target images
+corrsAll = []; % [time x alignedPlanes (numPlanes) x 
+               %  targetPlanes (length(planesToInterpolate)) x xFOVs]
+dsAllPlanes = []; % [time x [x,y] x alignedPlanes (numPlanes) x 
+                  %  targetPlanes (length(planesToInterpolate)) x xFOVs];
+for i = planesToInterpolate
+    dsFOV = [];
+    corrsFOV = [];
+    for j = 1:size(ops1,2)
+        % reshape ds to [frames x 2 x planes], and Corr to [frames
+        % x planes]; (need to add NaNs at end of each experiment if last
+        % frame was not recorded in last plane)
+        ds = [];
+        corrs = [];
+        t = 0;
+        for k = 1:length(ops1{i,j}.Nframes)
+            d = ops1{i,j}.DS(t + (1:ops1{i,j}.Nframes(k)),:);
+            c = ops1{i,j}.CorrFrame(t + (1:ops1{i,j}.Nframes(k)));
+            framesToAdd = ceil(size(d,1)/nplanes)*nplanes - size(d,1);
+            d = permute(reshape([d; NaN(framesToAdd,2)], ...
+                nplanes, [], 2), [2 3 1]);
+            c = reshape([c; NaN(framesToAdd,1)], nplanes, [])';
+            ds = [ds; d];
+            corrs = [corrs; c];
+            t = t + ops1{i,j}.Nframes(k);
+            fr = floor(ops1{i,j}.Nframes(k)/nplanes) + ...
+                double(mod(ops1{i,j}.Nframes(k), nplanes) >= i);
+            ops1{i,j}.Nframes(k) = fr;
+        end
+        ops1{i,j}.DS = ds; % [time x 2 x nplanes]
+        ops1{i,j}.CorrFrame = corrs; % [time x nplanes]
+        dsFOV = cat(5, dsFOV, ds);
+        corrsFOV = cat(4, corrsFOV, corrs);
+    end
+    corrsAll = cat(3, corrsAll, corrsFOV);
+    dsAllPlanes = cat(4, dsAllPlanes, dsFOV);
+end
+for i = setdiff(2:nplanes, planesToInterpolate)
+    for j = 1:size(ops1,2)
+        ds = [];
+        corrs = [];
+        t = 0;
+        for k = 1:length(ops1{i,j}.Nframes)
+            d = NaN(ops1{1,j}.Nframes(k),2);
+            d(1:ops1{i,j}.Nframes(k),:) = ops1{i,j}.DS(t + (1:ops1{i,j}.Nframes(k)),:);
+            c = NaN(ops1{1,j}.Nframes(k),1);
+            c(1:ops1{i,j}.Nframes(k)) = ops1{i,j}.CorrFrame(t + (1:ops1{i,j}.Nframes(k)));
+            ds = [ds; d];
+            corrs = [corrs; c];
+            t = t + ops1{i,j}.Nframes(k);
+        end
+        ops1{i,j}.DS = ds;
+        ops1{i,j}.CorrFrame = corrs;
+    end
+end
+
+% find z-shifts in data; assume that whole stack is moving together
+% (won't detect very fast z-shifts)
+% only consider non-flyback planes here and average across all tiles of
+% plane
+corrsAll = mean(corrsAll(:,planesToInterpolate,:,:),4);
+corrsNorm = bsxfun(@rdivide, corrsAll, max(corrsAll,[],2));
+% for each possible shift in z, average alignment correlations across all
+% planes (except those that are shifted outside of stack)
+diags = -size(corrsAll,3)+2 : size(corrsAll,3)-2; % ignore maximum possible shift
+elems = 2:size(corrsAll,3);
+elems = [elems, flip(elems(1:end-1))];
+diagonals = zeros(size(corrsAll,2),size(corrsAll,3),length(diags));
+for d = 1:length(diags)
+    diagonals(:,:,d) = diag(ones(1,elems(d)),diags(d));
+end
+diagonals = diagonals==1;
+sh = zeros(size(corrsAll,1),length(diags));
+for t = 1:size(corrsAll,1)
+    t1 = squeeze(corrsNorm(t,:,:));
+    for d = 1:length(diags)
+        dgnl = diagonals(:,:,d);
+        sh(t,d) = nansum(t1(dgnl))./sum(~isnan(t1(dgnl)));
+    end
+end
+% for each frame, determine shift resulting in maximal alignment correlation
+[corrs,inds] = max(sh,[],2);
+shifts = diags(inds); % use shifts like this: bestTargetImage(t) = plane + shifts(t)
+                      %                       bestPlane(t) = targetImage - shifts(t)
+slowShifts = round(medfilt1(shifts,500));
+ops2.CorrFrame = corrs;
+outliers = getOutliers(ops2);
+outliers = union(outliers, find(abs(shifts-slowShifts) > ...
+    round(length(planesToInterpolate)/5)));
+shifts(outliers) = slowShifts(outliers);
+
+if getOr(ops, 'fig', 1) == 1
+    figure
+    plot(shifts)
+    hold on
+    yLimits = get(gca, 'YLim');
+    plot(repmat(cumsum(ops1{1}.Nframes(1:end-1)),2,1), ...
+        repmat(yLimits(:), 1, length(ops1{1}.Nframes)-1), 'r')
+    xlabel('# Frames')
+    ylabel('Shift in z direction')
+end
+
+% determine those planes that can be followed through the whole
+% recording (while accounting for z-shifts)
+indInterpolate = 1+max(shifts) : ...
+    length(planesToInterpolate)+min(shifts);
+planesToInterp = planesToInterpolate(indInterpolate); % target images
+% of these planes will be used (at every time, there is one frame whose
+% best matching target image is one of these target images)
+
+% determine which planes are highly correlated to each other
+% (similar neihgbouring planes); those will be averaged
+corrsPadded = [NaN(size(corrsNorm)), corrsNorm, NaN(size(corrsNorm))];
+for t = 1:size(corrsNorm,1)
+    corrsPadded(t,:,:) = circshift(corrsPadded(t,:,:),shifts(t),2);
+end
+profiles = squeeze(nanmean(corrsPadded(:,size(corrsNorm,2)+ ...
+    (1:size(corrsNorm,2)),:), 1));
+ind = profiles>=0.8;
+sngls = find(sum(ind,1) < 2);
+for k = sngls
+    [~,j] = sort(profiles(:,k),'descend');
+    ind(j(2),k) = true;
+end
+profiles(~ind) = NaN;
+profiles = bsxfun(@rdivide, profiles, nansum(profiles,1)); % [planesToInterpolate x planesToInterpolate]
+if getOr(ops, 'fig', 1) == 1
+    figure
+    imagesc(profiles)
+    xlabel('Target images')
+    ylabel('Aligned planes')
+    title('Z-profiles')
+end
+
+% for each frame, select registration offset: align to best matching
+% target image
+T = size(dsAllPlanes,1);
+Dims = size(dsAllPlanes,2);
+dsall = NaN(T*nplanes, 2, size(ops1,2));
+% (1) collect dsall for flyback planes (not in planesToInterpolate)
+for i = setdiff(1:nplanes, planesToInterpolate)
+    for j = 1:size(ops1,2)
+        indframes = ops.planesToProcess(i):nplanes:(T*nplanes);
+        ds = ops1{i,j}.DS;
+        indframes(length(ds)+1:end) = [];
+        dsall(indframes,:,j) = ds;
+        
+        ops1{i,j}.planeInterpolated = 0;
+        up = false(size(ds,1), nplanes);
+        up(:,i) = true;
+        ops1{i,j}.usedPlanes = up;
+    end
+end
+% (2) collect dsall for all planes that will be interpolated
+for i = 1:length(planesToInterpolate)
+    indframes = planesToInterpolate(i):nplanes:(T*nplanes);
+    ds = squeeze(dsAllPlanes(:,:,planesToInterpolate(i),:,:));
+    subscripts = cat(3, repmat((1:T)',1,Dims), ...
+        repmat(1:Dims,T,1), repmat((i + shifts)',1,Dims));
+    subscripts = reshape(subscripts, [], 3);
+    subscripts(subscripts(:,3)<1 | ...
+        subscripts(:,3)>length(planesToInterpolate), 3) = i;
+    linearInd = sub2ind(size(ds(:,:,:,1)), subscripts(:,1), subscripts(:,2), ...
+        subscripts(:,3));
+    
+    if ismember(i, indInterpolate)
+        prof = eye(nplanes);
+        prof(prof==0) = NaN;
+        prof(planesToInterpolate, planesToInterpolate) = profiles;
+        up = planesToInterpolate(i) - shifts';
+        up = prof(:,up)';
+        up = ~isnan(up);
+    end
+    for j = 1:size(ops1,2)
+        d = ds(:,:,:,j);
+        values = d(linearInd);
+        values = reshape(values, T, Dims);
+        dsall(indframes,:,j) = values;
+    
+        if ismember(i, indInterpolate)
+            ops1{planesToInterpolate(i),j}.planeInterpolated = 1;
+            ops1{planesToInterpolate(i),j}.usedPlanes = up;
+            ops1{planesToInterpolate(i),j}.basisPlanes = planesToInterpolate(i) - shifts';
+            ops1{planesToInterpolate(i),j}.alignedToPlanes = ...
+                planesToInterpolate(i);
+            ops1{planesToInterpolate(i),j}.profiles = prof;
+        else
+            ops1{planesToInterpolate(i),j}.planeInterpolated = 0;
+            up = false(size(ds,1), nplanes);
+            up(:,planesToInterpolate(i)) = true;
+            ops1{planesToInterpolate(i),j}.usedPlanes = up;
+            ap = planesToInterpolate(i) + shifts';
+            ap(ap<planesToInterpolate(1) | ap>planesToInterpolate(end)) = ...
+                planesToInterpolate(i);
+            ops1{planesToInterpolate(i),j}.alignedToPlanes = ap;
+        end
+    end
+end
+
+% align frames and write movie
+iplane0 = 1:1:ops.nplanes;
+t2 = 0;
+% if two consecutive files have as many bytes, they have as many frames
+nbytes = 0;
+for k = 1:length(fs)
+    dataPrev = zeros(ops.Ly, ops.Lx, nplanes, 'int16');
+    t1 = 0;
+    for j = 1:length(fs{k})
+        % load frames of all planes
+        if abs(nbytes - fs{k}(j).bytes)>1e3
+            nbytes = fs{k}(j).bytes;
+            nFr = nFramesTiff(fs{k}(j).name);
+        end
+        iplane0 = mod(iplane0-1, nplanes) + 1;
+        
+        if mod(nFr, ops.nchannels) ~= 0
+            fprintf('  WARNING: number of frames in tiff (%d) is NOT a multiple of number of channels!\n', j);
+        end
+        ichanset = [ichannel; nFr; ops.nchannels];
+        data = loadFramesBuff(fs{k}(j).name, ichanset(1), ichanset(2), ichanset(3));
+        if BiDiPhase
+            yrange = 2:2:Ly;
+            if BiDiPhase>0
+                data(yrange, (1+BiDiPhase):Lx,:) = data(yrange, 1:(Lx-BiDiPhase),:);
+            else
+                data(yrange, 1:Lx+BiDiPhase,:) = data(yrange, 1-BiDiPhase:Lx,:);
+            end
+        end
+        
+        % align frames according to determined registration offsets
+        dreg = RegMovie(data, ops1, dsall(t1+t2+(1:size(data,3)),:,:), yFOVs, xFOVs);
+        
+        % for each plane, write aligned movie to bin file+
+        for i = 1:nplanes
+            ifr0 = iplane0(ops.planesToProcess(i));
+            indframes = ifr0:nplanes:size(data,3);
+            dwrite = dreg(:,:,indframes);
+            fwrite(fid{i}, dwrite, class(data));
+            
+            ops1{i}.mimg1 = ops1{i}.mimg1 + sum(dwrite,3);
+        end
+        
+        if interpolateAcrossPlanes && ~isempty(RegFileBinLocation)
+            % use frames of plane that match best to target image of
+            % current plane and average across similar planes
+            dataNext = [];
+            for i = indInterpolate
+                ind1 = iplane0(planesToInterpolate(i)) : nplanes : size(data,3);
+                sh = shifts(ceil((t1+t2)/nplanes + (1:length(ind1))));
+                uniqueShifts = unique(sh);
+                dwrite = zeros(size(dreg,1),size(dreg,2),length(ind1));
+                for s = uniqueShifts
+                    planesInv = find(~isnan(profiles(:,i-s)))';
+                    diffs = planesInv - i;
+                    for pl = 1:length(planesInv)
+                        ind2 = ind1 + diffs(pl); % smallest possible value: -nplanes+1,
+                        % largest possible values: size(dreg,3)+nplanes
+                        ind2(sh~=s) = [];
+                        weight = profiles(planesInv(pl),i-s);
+                        if ind2(1)<1 % frame is part of previously loaded tiff file (can happen if frames per tiff are not mupltiple of planes)
+                            dwrite(:,:,1) = dwrite(:,:,1) + ...
+                                weight .* double(dataPrev(:,:,end-ind2(1)));
+                            ind2(1) = [];
+                        end
+                        if ind2(end)>size(dreg,3) % frame is part of upcoming tiff file
+                            if j<length(fs{k})
+                                if isempty(dataNext) % load first few frames of next tiff and register them
+                                    ichanset = [ichannel; nplanes; ops.nchannels];
+                                    data = loadFramesBuff(fs{k}(j+1).name, ichanset(1), ichanset(2), ichanset(3));
+                                    if BiDiPhase
+                                        yrange = 2:2:Ly;
+                                        if BiDiPhase>0
+                                            data(yrange, (1+BiDiPhase):Lx,:) = data(yrange, 1:(Lx-BiDiPhase),:);
+                                        else
+                                            data(yrange, 1:Lx+BiDiPhase,:) = data(yrange, 1-BiDiPhase:Lx,:);
+                                        end
+                                    end
+                                    dataNext = register_movie(data, ops, ...
+                                        dsall((t1+t2) + ceil(size(data,3)/nplanes)* ...
+                                        nplanes + 1:nplanes,:));
+                                end
+                                dwrite(:,:,end) = dwrite(:,:,end) + weight .*...
+                                    double(dataNext(:,:,ind2(end)-size(dreg,3)));
+                            end
+                            ind2(end) = [];
+                        end
+                        dwrite(:,:,ceil(ind2/nplanes)) = dwrite(:,:,ceil(ind2/nplanes)) + ...
+                            weight .* double(dreg(:,:,ind2));
+                    end
+                end
+                fwrite(fidIntpol{ops.planesToProcess(planesToInterpolate(i))}, dwrite, class(data));
+            end
+        end
+        dataPrev = dreg(:,:,end-nplanes+1:end);
+        t1 = t1 + size(dreg,3);
+    end
+    t2 = t2 + ceil(t1/nplanes)*nplanes;
+end


### PR DESCRIPTION
These are the changes I made in order to register dense z-stacks, which suffer from movement in z-direction (slow and fast). The added features are described in the commit, and also show up in the beginning of reg2P.m
I tested it on my retinal bouton movie using all the features, but not on data without using the new features (although I tried to incorporate all of the old functionality, of course).