### PR TITLE
Non rigid block reg

### DIFF
--- a/nonRigidRegistration/GetBlockOffsets.m
+++ b/nonRigidRegistration/GetBlockOffsets.m
@@ -1,12 +1,22 @@
 % computes registration offsets for data split into blocks
 % loops over blocks and returns offsets dsall
 function [dsall,ops1] = GetBlockOffsets(data, j, iplane0, ops, ops1)
-            
+
+nplanes = getOr(ops, {'nplanes'}, 1);
+alignAcrossPlanes  = getOr(ops, {'alignAcrossPlanes'}, false);
+planesToInterpolate = getOr(ops, {'planesToInterpolate'}, 1:nplanes);
+
 nblocks = ops.numBlocks(1)*ops.numBlocks(2);
 dsall = zeros(size(data,3), 2, nblocks);
+
 for i = 1:ops.numPlanes
-    ifr0 = iplane0(ops.planesToProcess(i));
-    indframes = ifr0:ops.nplanes:size(data,3);
+    if alignAcrossPlanes && ismember(i, planesToInterpolate) % load frames of all planes
+        indframes = 1:size(data,3);
+    else
+        ifr0 = iplane0(ops.planesToProcess(i));
+        indframes = ifr0:ops.nplanes:size(data,3);
+    end
+    
     ds = zeros(numel(indframes), 2, nblocks,'double');
     Corr = zeros(numel(indframes), nblocks,'double');
     for ib = 1:nblocks

--- a/nonRigidRegistration/blockReg2P.m
+++ b/nonRigidRegistration/blockReg2P.m
@@ -13,18 +13,24 @@ end
 % ops.numBlocks(1) = # of blocks in Y, ops.numBlocks(2) = # of blocks in X
 ops.numBlocks      = getOr(ops, {'numBlocks'}, [8 1]);
 numBlocks          = ops.numBlocks;
+
 numPlanes = length(ops.planesToProcess);
 ops.numPlanes = numPlanes;
-chunk_align        = getOr(ops, {'chunk_align'}, 1);
 nplanes            = getOr(ops, {'nplanes'}, 1);
 nchannels          = getOr(ops, {'nchannels'}, 1);
 ichannel           = getOr(ops, {'gchannel'}, 1);
 rchannel           = getOr(ops, {'rchannel'}, 2);
 red_align          = getOr(ops, {'AlignToRedChannel'}, 0); % register frames using red channel
-LoadRegMean        = getOr(ops, {'LoadRegMean'}, 0);
-ops.RegFileBinLocation = getOr(ops, {'RegFileBinLocation'}, []); % binary file location
+
+RegFileBinLocation = getOr(ops, {'RegFileBinLocation'}, []); % binary file location
+alignTargetImages  = getOr(ops, {'alignTargetImages'}, false); % if true, align target images to each other
+interpolateAcrossPlanes = getOr(ops, {'interpolateAcrossPlanes'}, false); %if true, similar looking planes will be averaged together to generate final movie
+planesToInterpolate = getOr(ops, {'planesToInterpolate'}, 1:nplanes); % these planes will be considered for interpolation
+alignAcrossPlanes  = getOr(ops, {'alignAcrossPlanes'}, false); % at each time point, frame will be aligned to best matching target image (from different planes)
+
 ops.splitFOV           = getOr(ops, {'splitFOV'}, [1 1]); % split FOV into chunks if memory issue
 % ops.splitFOV(1) = # of subsets in Y, ops.splitFOV(2) = # of subsets in X
+ops.smooth_time_space  = getOr(ops, 'smooth_time_space', []);
 ops.RegFileTiffLocation = getOr(ops, {'RegFileTiffLocation'}, []); % write registered tiffs to disk
 
 % bidirectional phase offset computation
@@ -39,13 +45,15 @@ BiDiPhase              = ops.BiDiPhase;
 
 fs = ops.fsroot;
 
+%% find the mean frame after aligning a random subset
+
+% check if there are tiffs in directory
 try
-   IMG = loadFramesBuff(fs{1}(1).name, 1, 1, 1); 
+    IMG = loadFramesBuff(fs{1}(1).name, 1, 1, 1);
 catch
     error('could not find any tif or tiff, check your path');
 end
 
-% find the mean frame after aligning a random subset
 if ops.doRegistration
     [IMG] = GetRandFrames(fs, ops);    
     [Ly, Lx, ~, ~] = size(IMG);
@@ -78,17 +86,51 @@ if ops.doRegistration
     
     % for each plane: align chosen frames to average to generate target image
     % aligned in blocks
+    ops1 = cell(numPlanes, 1);
     for i = 1:numPlanes
-        ops1{i} = blockAlignIterative(squeeze(IMG(:,:,ops.planesToProcess(i),:)), ops);
+        if ~(interpolateAcrossPlanes || alignAcrossPlanes)
+            ops1{i} = blockAlignIterative(squeeze( ...
+                IMG(:,:,ops.planesToProcess(i),:)), ops);
+        else
+            ops1{i} = align_iterative(single(squeeze(IMG(:,:,...
+                ops.planesToProcess(i),:))), ops);
+        end
+    end
+    
+    if alignTargetImages % align target images of all planes to each other
+        % (reasonable only if interplane distance during imaging was small)
+        ds = zeros(length(planesToInterpolate), 2);
+        % planesToInterpolate should be indices of non-flyback planes
+        % (only those should be aligned)
+        for i = 2:length(planesToInterpolate) % align consecutive planes
+            pl = planesToInterpolate(i);
+            ds(i,:) = registration_offsets(ops1{pl}.mimg, ops1{pl-1}, 0);
+        end
+        ds = cumsum(ds,1);
+        ds = bsxfun(@minus, ds, mean(ds,1));
+        images = zeros(Ly, Lx, length(planesToInterpolate));
+        for i = 1:length(planesToInterpolate)
+            images(:,:,i) = ops1{planesToInterpolate(i)}.mimg;
+        end
+        ds = reshape(permute(ds, [1 3 2]), [], 2);
+        images = reshape(images, Ly, Lx, []);
+        newTargets = register_movie(images, ops, ds);
+        newTargets = reshape(newTargets, Ly, Lx, ...
+            length(planesToInterpolate));
+        for i = 1:length(planesToInterpolate)
+            ops1{planesToInterpolate(i)}.mimg = newTargets(:,:,i);
+        end
     end
     
     % display target image
-   if ops.showTargetRegistration
-       PlotRegMean(ops1,ops);
-   end
+    if ops.showTargetRegistration
+        PlotRegMean(ops1,ops);
+        drawnow
+    end
 % do not compute target mean image   
 else
     [Ly, Lx] = size(IMG);
+    ops1 = cell(numPlanes, 1);
     for i = 1:numPlanes
         ops1{i} = ops;
         ops1{i}.mimg = zeros(Ly, Lx);
@@ -98,8 +140,13 @@ else
 end
 clear IMG
 
-
+%% open files for registration
 % prepare individual options files and open binaries
+fid = cell(numPlanes, 1);
+fidIntpol = [];
+if ops.interpolateAcrossPlanes == 1 && ~isempty(RegFileBinLocation)
+    fidIntpol = cell(numPlanes, 1);
+end
 for i = 1:numPlanes
     ops1{i}.RegFile = fullfile(ops.RegFileRoot, ...
         sprintf('%s_%s_%s_plane%d.bin', ops.mouse_name, ops.date, ...
@@ -112,32 +159,56 @@ for i = 1:numPlanes
     fid{i}             = fopen(ops1{i}.RegFile, 'w');
     ops1{i}.DS          = [];
     ops1{i}.CorrFrame   = [];
-    ops1{i}.mimg1       = ops1{i}.mimg;
+    ops1{i}.mimg1       = zeros(Ly, Lx);
     for ib = 1:numBlocks(1)*numBlocks(2)
         ops1{i}.mimgB{ib} = ops1{i}.mimg(ops1{i}.yBL{ib}, ops1{i}.xBL{ib});
     end
+    
+    if interpolateAcrossPlanes && ~isempty(RegFileBinLocation)
+        % open separate files for result after averaging across
+        % neighbouring planes
+        str = sprintf('%d_',ops1{i}.expts);
+        str(end) = [];
+        folder = fullfile(ops1{i}.RegFileBinLocation, ops1{i}.mouse_name, ...
+            ops1{i}.date, str, 'interpolated');
+        if ~exist(folder, 'dir')
+            mkdir(folder);
+        end
+        fidIntpol{i} = fopen(fullfile(folder, ...
+            sprintf('%s_%s_%s_plane%d.bin', ops.mouse_name, ops.date, ...
+            ops.CharSubDirs, i)), 'w');
+    end
 end
+
+%% compute registration offsets from mean img for each frame
 nbytes = fs{1}(1).bytes;
 nFr = nFramesTiff(fs{1}(1).name);
 
-
-% compute registration offsets from mean img for each frame
 xyValid = true(Ly, Lx);
 tic
 for k = 1:length(fs)
+    % initialize frame count
     for i = 1:numPlanes
          ops1{i}.Nframes(k)  = 0;
     end
-    iplane0 = 1:1:ops.nplanes;
+    
+    iplane0 = 1:1:ops.nplanes; % identity of planes for first frames in tiff file
     for j = 1:length(fs{k})
         iplane0 = mod(iplane0-1, numPlanes) + 1;
-        nFr = nFramesTiff(fs{k}(j).name);
+        % only compute number of frames if size of tiff is different
+        % from previous tiff
+        if abs(nbytes - fs{k}(j).bytes)>1e3
+            nbytes = fs{k}(j).bytes;
+            nFr = nFramesTiff(fs{k}(j).name);
+        end
         if red_align
             ichanset = [rchannel; nFr; nchannels];
         else
             ichanset = [ichannel; nFr; nchannels];
         end
-        data = loadFramesBuff(fs{k}(j).name, ichanset(1), ichanset(2), ichanset(3), ops.temp_tiff);
+        % only load frames of registration channel
+        data = loadFramesBuff(fs{k}(j).name, ichanset(1), ichanset(2), ...
+            ichanset(3), ops.temp_tiff);
 
         if abs(BiDiPhase) > 0
             data = ShiftBiDi(BiDiPhase, data, Ly, Lx);
@@ -146,32 +217,41 @@ for k = 1:length(fs)
         if ops.doRegistration
             % get the registration offsets
             [dsall, ops1] = GetBlockOffsets(data, j, iplane0, ops, ops1);
-                    
-            % if aligning by the red channel, data needs to be reloaded as the
-            % green channel
-            if red_align
-                if mod(nFr, nchannels) ~= 0
-                    fprintf('  WARNING: number of frames in tiff (%d) is NOT a multiple of number of channels!\n', j);
-                end
-                ichanset = [ichannel; nFr; nchannels];
-                data = loadFramesBuff(ops.temp_tiff, ichanset(1), ichanset(2), ichanset(3));               
-            end
             
-            % register frames
-            [dreg, xyValid] = BlockRegMovie(data, ops, dsall, xyValid);
+            if ~alignAcrossPlanes
+                % if aligning by the red channel, data needs to be reloaded as the
+                % green channel
+                if red_align
+                    if mod(nFr, nchannels) ~= 0
+                        fprintf('  WARNING: number of frames in tiff (%d) is NOT a multiple of number of channels!\n', j);
+                    end
+                    ichanset = [ichannel; nFr; nchannels];
+                    data = loadFramesBuff(ops.temp_tiff, ichanset(1), ichanset(2), ichanset(3));
+                    % shift green channel by same bidiphase offset
+                    if abs(BiDiPhase) > 0
+                        data = ShiftBiDi(BiDiPhase, data, Ly, Lx);
+                    end
+                end
+                
+                % register frames
+                [dreg, xyValid] = BlockRegMovie(data, ops, dsall, xyValid);
+            end
        
         else
             dreg = data;
         end
+        
         % write dreg to bin file+
-        for i = 1:numPlanes
-            ifr0 = iplane0(ops.planesToProcess(i));
-            indframes = ifr0:nplanes:size(data,3);
-            dwrite = dreg(:,:,indframes);
-            fwrite(fid{i}, dwrite, class(data));
-            
-            ops1{i}.Nframes(k) = ops1{i}.Nframes(k) + size(dwrite,3);
-            ops1{i}.mimg1 = ops1{i}.mimg1 + sum(dwrite,3);
+        if ~alignAcrossPlanes
+            for i = 1:numPlanes
+                ifr0 = iplane0(ops.planesToProcess(i));
+                indframes = ifr0:nplanes:size(data,3);
+                dwrite = dreg(:,:,indframes);
+                fwrite(fid{i}, dwrite, class(data));
+                
+                ops1{i}.Nframes(k) = ops1{i}.Nframes(k) + size(dwrite,3);
+                ops1{i}.mimg1 = ops1{i}.mimg1 + sum(dwrite,3);
+            end
         end
         
         if rem(j,5)==1
@@ -180,9 +260,22 @@ for k = 1:length(fs)
         
         iplane0 = iplane0 - nFr/nchannels;
     end
-    for i = 1:numPlanes
-        ops1{i}.mimg1 = ops1{i}.mimg1/ops1{i}.Nframes(k);
-    end    
+    if alignAcrossPlanes
+        for i = 1:numPlanes
+            ops1{i}.Nframes(k) = size(ops1{i}.DS,1) - sum(ops1{i}.Nframes(1:k-1));
+        end
+    end
+end
+
+if alignAcrossPlanes && ops.doRegistration % align each frame with the best matching target image
+    [ops1, planesToInterp, xyValid] = registerBlocksAcrossPlanes(ops1, ...
+        ops, fid, fidIntpol);
+end
+
+for i = 1:numel(ops1)
+    ops1{i}.mimg1 = ops1{i}.mimg1/sum(ops1{i}.Nframes);
+    
+    ops1{i}.badframes = false(1, size(ops1{i}.DS,1));
 end
 
 %% write binary file to tiffs if ~isempty(ops.RegFileTiffLocation)
@@ -214,21 +307,63 @@ for i = 1:numPlanes
             fwrite(fidCopy, data, class(data));
         end
         fclose(fidCopy);
+        fclose(fid{i});
+        
+        if ops.interpolateAcrossPlanes == 1 && ~isempty(RegFileBinLocation)
+            fclose(fidIntpol{i});
+            folder = fullfile(ops1{i}.RegFileBinLocation, ops1{i}.mouse_name, ...
+                ops1{i}.date, ops.CharSubDirs, 'interpolated');
+            filename = fullfile(folder, ...
+                sprintf('%s_%s_%s_plane%d.bin', ops.mouse_name, ops.date, ...
+                ops.CharSubDirs, i));
+            if ismember(i, planesToInterp)
+                fidCopy = fopen(ops1{i}.RegFile, 'w');
+                fidOrig = fopen(filename, 'r');
+                sz = ops1{i}.Lx * ops1{i}.Ly;
+                parts = ceil(sum(ops1{i}.Nframes) / 2000);
+                for p = 1:parts
+                    toRead = 2000;
+                    if p == parts
+                        toRead = sum(ops1{i}.Nframes) - 2000 * (parts-1);
+                    end
+                    data = fread(fidOrig,  sz*toRead, '*int16');
+                    fwrite(fidCopy, data, class(data));
+                end
+                fclose(fidCopy);
+                fclose(fidOrig);
+            else
+                delete(filename)
+            end
+        end
     end
-    fclose(fid{i});
 end
 %%
 % compute xrange, yrange
 for i = 1:numPlanes
     if ops.doRegistration
-%         badi                    = getOutliers(ops1{i}); 
-%         ops1{i}.badframes(badi) = true;
-        ops1{i}.badframes = false(sum(ops1{i}.Nframes), 1);
+        ops2 = ops1{i};
+        ops2.CorrFrame = nanmean(ops2.CorrFrame,2);
+        badi = getOutliers(ops2); 
+        ops1{i}.badframes(badi) = true;
+%         ops1{i}.badframes = false(sum(ops1{i}.Nframes), 1);
+
+        ds = ops1{i}.DS(~ops1{i}.badframes,:,:);
+        maxDsY = max(reshape(ds(:,1,1:numBlocks(1)), [], 1));
+        minDsY = min(reshape(ds(:,1,end-numBlocks(1)+1:end), [], 1));
+        maxDsX = max(reshape(ds(:,2,1:numBlocks(1):end), [], 1));
+        minDsX = min(reshape(ds(:,2,numBlocks(1):numBlocks(1):end), [], 1));
+        if BiDiPhase>0
+            maxDsX = max(1+BiDiPhase, maxDsX);
+        elseif BiDiPhase<0
+            minDsX = min(BiDiPhase, minDsX);
+        end
+        ops1{i}.yrange = ceil(1 + maxDsY) : floor(ops1{i}.Ly+minDsY);
+        ops1{i}.xrange = ceil(1 + maxDsX) : floor(ops1{i}.Lx+minDsX);
         
         %         minDs = min(min(ops1{i}.DS(2:end, :,:), [], 3), [], 1);
         %         maxDs = max(max(ops1{i}.DS(2:end, :,:), [], 3), [], 1);
-        ops1{i}.yrange  = find(xyValid(:, ceil(Lx/2)));
-        ops1{i}.xrange  = find(xyValid(ceil(Ly/2), :));
+%         ops1{i}.yrange  = find(xyValid(:, ceil(Lx/2)));
+%         ops1{i}.xrange  = find(xyValid(ceil(Ly/2), :));
         
     else
         ops1{i}.yrange = 1:Ly;

--- a/registration/registerBlocksAcrossPlanes.m
+++ b/registration/registerBlocksAcrossPlanes.m
@@ -1,0 +1,328 @@
+function [ops1, planesToInterp, xyValid] = registerBlocksAcrossPlanes( ...
+    ops1, ops, fid, fidIntpol)
+
+nplanes = getOr(ops, {'nplanes'}, 1);
+planesToInterpolate = getOr(ops, {'planesToInterpolate'}, 1:nplanes);
+ichannel = getOr(ops, {'gchannel'}, 1);
+BiDiPhase = getOr(ops, {'BiDiPhase'}, 0);
+RegFileBinLocation = getOr(ops, {'RegFileBinLocation'}, []);
+interpolateAcrossPlanes = getOr(ops, {'interpolateAcrossPlanes'}, false);
+fs = ops.fsroot;
+numBlocks = prod(ops.numBlocks);
+
+% in order to determine optimal shifts in z at each time point, collect 
+% registration offsets and correlations of all frames with all target images
+corrsAll = []; % [time x alignedPlanes (numPlanes) x 
+               %  targetPlanes (length(planesToInterpolate)) x numBlocks]
+dsAllPlanes = []; % [time x [x,y] x alignedPlanes (numPlanes) x 
+                  %  targetPlanes (length(planesToInterpolate)) x numBlocks];
+for i = planesToInterpolate
+    % reshape ds to [frames x 2 x planes x numBlocks], and
+    % Corr to [frames x planes x numBlocks]; (need to add NaNs at end
+    % of each experiment if last frame was not recorded in last plane)
+    ds = [];
+    corrs = [];
+    t = 0;
+    for k = 1:length(ops1{i}.Nframes)
+        d = ops1{i}.DS(t + (1:ops1{i}.Nframes(k)),:,:);
+        c = ops1{i}.CorrFrame(t + (1:ops1{i}.Nframes(k)),:);
+        framesToAdd = ceil(size(d,1)/nplanes)*nplanes - size(d,1);
+        d = permute(reshape([d; NaN(framesToAdd,2,size(d,3))], ...
+            nplanes, [], 2, numBlocks), [2 3 1 4]);
+        c = permute(reshape([c; NaN(framesToAdd,size(c,2))], ...
+            nplanes, [], numBlocks), [2 1 3]);
+        ds = [ds; d];
+        corrs = [corrs; c];
+        t = t + ops1{i}.Nframes(k);
+        fr = floor(ops1{i}.Nframes(k)/nplanes) + ...
+            double(mod(ops1{i}.Nframes(k), nplanes) >= i);
+        ops1{i}.Nframes(k) = fr;
+    end
+    ops1{i}.DS = ds; % [time x 2 x nplanes x numBlocks]
+    ops1{i}.CorrFrame = corrs; % [time x nplanes x numBlocks]
+    
+    if ~isempty(dsAllPlanes) && size(ds,1)<size(dsAllPlanes,1)
+        ds(end+1:size(dsAllPlanes,1),:,:,:) = NaN;
+        corrs(end+1:size(corrsAll,1),:,:) = NaN;
+    end
+    dsAllPlanes = cat(4, dsAllPlanes, permute(ds, [1 2 3 5 4]));
+    corrsAll = cat(3, corrsAll, permute(corrs, [1 2 4 3]));
+end
+for i = setdiff(2:nplanes, planesToInterpolate)
+    ds = [];
+    corrs = [];
+    t = 0;
+    for k = 1:length(ops1{i}.Nframes)
+        d = NaN(ops1{1}.Nframes(k),2,numBlocks);
+        d(1:ops1{i}.Nframes(k),:,:) = ops1{i}.DS(t + (1:ops1{i}.Nframes(k)),:,:);
+        c = NaN(ops1{1}.Nframes(k),numBlocks);
+        c(1:ops1{i}.Nframes(k),:) = ops1{i}.CorrFrame(t + (1:ops1{i}.Nframes(k)),:);
+        ds = [ds; d];
+        corrs = [corrs; c];
+        t = t + ops1{i}.Nframes(k);
+    end
+    ops1{i}.DS = ds;
+    ops1{i}.CorrFrame = corrs;
+end
+
+% find z-shifts in data; assume that whole stack is moving together
+% (won't detect very fast z-shifts)
+% only consider non-flyback planes here and average across all blocks of
+% plane
+corrsAll = mean(corrsAll(:,planesToInterpolate,:,:),4);
+corrsNorm = bsxfun(@rdivide, corrsAll, max(corrsAll,[],2));
+% for each possible shift in z, average alignment correlations across all
+% planes (except those that are shifted outside of stack)
+diags = -size(corrsAll,3)+2 : size(corrsAll,3)-2; % ignore maximum possible shift
+elems = 2:size(corrsAll,3);
+elems = [elems, flip(elems(1:end-1))];
+diagonals = zeros(size(corrsAll,2),size(corrsAll,3),length(diags));
+for d = 1:length(diags)
+    diagonals(:,:,d) = diag(ones(1,elems(d)),diags(d));
+end
+diagonals = diagonals==1;
+sh = zeros(size(corrsAll,1),length(diags));
+for t = 1:size(corrsAll,1)
+    t1 = squeeze(corrsNorm(t,:,:));
+    for d = 1:length(diags)
+        dgnl = diagonals(:,:,d);
+        sh(t,d) = nansum(t1(dgnl))./sum(~isnan(t1(dgnl)));
+    end
+end
+% for each frame, determine shift resulting in maximal alignment correlation
+[corrs,inds] = max(sh,[],2);
+shifts = diags(inds); % use shifts like this: bestTargetImage(t) = plane + shifts(t)
+                      %                       bestPlane(t) = targetImage - shifts(t)
+slowShifts = round(medfilt1(shifts,500));
+ops2.CorrFrame = corrs;
+outliers = getOutliers(ops2);
+outliers = union(outliers, find(abs(shifts-slowShifts) > ...
+    round(length(planesToInterpolate)/5)));
+shifts(outliers) = slowShifts(outliers);
+
+if getOr(ops, 'fig', 1) == 1
+    figure
+    plot(shifts)
+    hold on
+    yLimits = get(gca, 'YLim');
+    plot(repmat(cumsum(ops1{1}.Nframes(1:end-1)),2,1), ...
+        repmat(yLimits(:), 1, length(ops1{1}.Nframes)-1), 'r')
+    xlabel('# Frames')
+    ylabel('Shift in z direction')
+end
+
+% determine those planes that can be followed through the whole
+% recording (while accounting for z-shifts)
+indInterpolate = 1+max(shifts) : ...
+    length(planesToInterpolate)+min(shifts);
+if isempty(indInterpolate)
+    disp('NOTE: no plane will be interpolated because range of shifts is too large')
+end
+planesToInterp = planesToInterpolate(indInterpolate); % target images
+% of these planes will be used (at every time, there is one frame whose
+% best matching target image is one of these target images)
+
+% determine which planes are highly correlated to each other
+% (similar neihgbouring planes); those will be averaged
+corrsPadded = [NaN(size(corrsNorm)), corrsNorm, NaN(size(corrsNorm))];
+for t = 1:size(corrsNorm,1)
+    corrsPadded(t,:,:) = circshift(corrsPadded(t,:,:),shifts(t),2);
+end
+profiles = squeeze(nanmean(corrsPadded(:,size(corrsNorm,2)+ ...
+    (1:size(corrsNorm,2)),:), 1));
+ind = profiles>=0.8;
+sngls = find(sum(ind,1) < 2);
+for k = sngls
+    [~,j] = sort(profiles(:,k),'descend');
+    ind(j(2),k) = true;
+end
+profiles(~ind) = NaN;
+profiles = bsxfun(@rdivide, profiles, nansum(profiles,1)); % [planesToInterpolate x planesToInterpolate]
+if getOr(ops, 'fig', 1) == 1
+    figure
+    imagesc(profiles, [0 max(profiles(:))])
+    xlabel('Target images')
+    ylabel('Aligned planes')
+    title('Z-profiles')
+end
+
+% for each frame, select registration offset: align to best matching
+% target image
+T = size(dsAllPlanes,1);
+Dims = size(dsAllPlanes,2);
+dsall = NaN(T*nplanes, 2, numBlocks);
+% (1) collect dsall for flyback planes (not in planesToInterpolate)
+for i = setdiff(1:nplanes, planesToInterpolate)
+    indframes = ops.planesToProcess(i):nplanes:(T*nplanes);
+    ds = ops1{i}.DS;
+    indframes(size(ds,1)+1:end) = [];
+    dsall(indframes,:,:) = ds;
+    
+    ops1{i}.planeInterpolated = 0;
+    up = false(size(ds,1), nplanes);
+    up(:,i) = true;
+    ops1{i}.usedPlanes = up;
+end
+% (2) collect dsall for all planes that will be interpolated
+for i = 1:length(planesToInterpolate)
+    indframes = planesToInterpolate(i):nplanes:(T*nplanes);
+    ds = squeeze(dsAllPlanes(:,:,planesToInterpolate(i),:,:));
+    subscripts = cat(3, repmat((1:T)',1,Dims), ...
+        repmat(1:Dims,T,1), repmat((i + shifts)',1,Dims));
+    subscripts = reshape(subscripts, [], 3);
+    subscripts(subscripts(:,3)<1, 3) = 1;
+    subscripts(subscripts(:,3)>length(planesToInterpolate), 3) = ...
+        length(planesToInterpolate);
+    linearInd = sub2ind(size(ds(:,:,:,1)), subscripts(:,1), subscripts(:,2), ...
+        subscripts(:,3));
+    
+    if ismember(i, indInterpolate)
+        prof = eye(nplanes);
+        prof(prof==0) = NaN;
+        prof(planesToInterpolate, planesToInterpolate) = profiles;
+        up = planesToInterpolate(i) - shifts';
+        up = prof(:,up)';
+        up = ~isnan(up);
+    end
+    for j = 1:numBlocks
+        d = ds(:,:,:,j);
+        values = d(linearInd);
+        values = reshape(values, T, Dims);
+        dsall(indframes,:,j) = values;
+    end
+    ops1{planesToInterpolate(i)}.DS_allPlanes = dsAllPlanes;
+    ops1{planesToInterpolate(i)}.CorrFrame_allPlanes = corrsAll;
+    values = dsall(indframes,:,:);
+    nanInds = isnan(values(:,1,1));
+    values(nanInds,:,:) = [];
+    ops1{planesToInterpolate(i)}.DS = values;
+    
+    if ismember(i, indInterpolate)
+        ops1{planesToInterpolate(i)}.planeInterpolated = 1;
+        ops1{planesToInterpolate(i)}.usedPlanes = up;
+        ops1{planesToInterpolate(i)}.basisPlanes = planesToInterpolate(i) - shifts';
+        ops1{planesToInterpolate(i)}.basisPlanes(nanInds) = [];
+        ops1{planesToInterpolate(i)}.profiles = prof;
+    else
+        ops1{planesToInterpolate(i)}.planeInterpolated = 0;
+        up = false(size(ds,1), nplanes);
+        up(:,planesToInterpolate(i)) = true;
+        ops1{planesToInterpolate(i)}.usedPlanes = up;
+    end
+    ap = planesToInterpolate(i) + shifts';
+    ap(ap<planesToInterpolate(1)) = planesToInterpolate(1);
+    ap(ap>planesToInterpolate(end)) = planesToInterpolate(end);
+    ops1{planesToInterpolate(i)}.alignedToPlanes = ap;
+    
+    ops =  ops1{planesToInterpolate(i)};
+    ops.CorrFrame(repmat(~ops.usedPlanes,1,1,numBlocks)) = NaN;
+    ops.CorrFrame = nanmean(nanmean(ops.CorrFrame,2),3); % average correlations across all used planes and all blocks
+    ops.CorrFrame(nanInds) = [];
+    ops1{planesToInterpolate(i)}.CorrFrame = ops.CorrFrame;
+    ops1{planesToInterpolate(i)}.usedPlanes(nanInds,:) = [];
+    ops1{planesToInterpolate(i)}.alignedToPlanes(nanInds) = [];
+end
+
+% align frames and write movie
+t2 = 0;
+% if two consecutive files have as many bytes, they have as many frames
+nbytes = 0;
+xyValid = true(ops.Ly, ops.Lx);
+for k = 1:length(fs)
+    dataPrev = zeros(ops.Ly, ops.Lx, nplanes, 'int16');
+    iplane0 = 1:1:ops.nplanes;
+    t1 = 0;
+    for j = 1:length(fs{k})
+        if abs(nbytes - fs{k}(j).bytes)>1e3
+            nbytes = fs{k}(j).bytes;
+            nFr = nFramesTiff(fs{k}(j).name);
+        end
+        iplane0 = mod(iplane0-1, nplanes) + 1;
+        
+        if mod(nFr, ops.nchannels) ~= 0
+            fprintf('  WARNING: number of frames in tiff (%d) is NOT a multiple of number of channels!\n', j);
+        end
+        % load frames of all planes
+        ichanset = [ichannel; nFr; ops.nchannels];
+        data = loadFramesBuff(fs{k}(j).name, ichanset(1), ichanset(2), ichanset(3));
+        if BiDiPhase
+            yrange = 2:2:Ly;
+            if BiDiPhase>0
+                data(yrange, (1+BiDiPhase):Lx,:) = data(yrange, 1:(Lx-BiDiPhase),:);
+            else
+                data(yrange, 1:Lx+BiDiPhase,:) = data(yrange, 1-BiDiPhase:Lx,:);
+            end
+        end
+        
+        % align frames according to determined registration offsets
+        [dreg, xyValid] = BlockRegMovie(data, ops, ...
+            dsall(t1+t2+(1:size(data,3)),:,:), xyValid);
+        
+        % for each plane, write aligned movie to bin file+
+        for i = 1:nplanes
+            ifr0 = iplane0(ops.planesToProcess(i));
+            indframes = ifr0:nplanes:size(data,3);
+            dwrite = dreg(:,:,indframes);
+            fwrite(fid{i}, dwrite, class(data));
+            
+            ops1{i}.mimg1 = ops1{i}.mimg1 + sum(dwrite,3);
+        end
+        
+        if interpolateAcrossPlanes && ~isempty(RegFileBinLocation)
+            % use frames of plane that match best to target image of
+            % current plane and average across similar planes
+            dataNext = [];
+            for i = indInterpolate
+                ind1 = iplane0(planesToInterpolate(i)) : nplanes : size(data,3);
+                sh = shifts(ceil((t1+t2)/nplanes + (1:length(ind1))));
+                uniqueShifts = unique(sh);
+                dwrite = zeros(size(dreg,1),size(dreg,2),length(ind1));
+                for s = uniqueShifts
+                    planesInv = find(~isnan(profiles(:,i-s)))';
+                    diffs = planesInv - i;
+                    for pl = 1:length(planesInv)
+                        ind2 = ind1 + diffs(pl); % smallest possible value: -nplanes+1,
+                        % largest possible values: size(dreg,3)+nplanes
+                        ind2(sh~=s) = [];
+                        weight = profiles(planesInv(pl),i-s);
+                        if ind2(1)<1 % frame is part of previously loaded tiff file (can happen if frames per tiff are not mupltiple of planes)
+                            dwrite(:,:,1) = dwrite(:,:,1) + ...
+                                weight .* double(dataPrev(:,:,end-ind2(1)));
+                            ind2(1) = [];
+                        end
+                        if ind2(end)>size(dreg,3) % frame is part of upcoming tiff file
+                            if j<length(fs{k})
+                                if isempty(dataNext) % load first few frames of next tiff and register them
+                                    ichanset = [ichannel; nplanes; ops.nchannels];
+                                    data = loadFramesBuff(fs{k}(j+1).name, ...
+                                        ichanset(1), ichanset(2), ichanset(3));
+                                    if BiDiPhase
+                                        yrange = 2:2:Ly;
+                                        if BiDiPhase>0
+                                            data(yrange, (1+BiDiPhase):Lx,:) = data(yrange, 1:(Lx-BiDiPhase),:);
+                                        else
+                                            data(yrange, 1:Lx+BiDiPhase,:) = data(yrange, 1-BiDiPhase:Lx,:);
+                                        end
+                                    end
+                                    dataNext = register_movie(data, ops, ...
+                                        dsall((t1+t2) + size(dreg,3) ...
+                                        + (1:nplanes),:));
+                                end
+                                dwrite(:,:,end) = dwrite(:,:,end) + weight .*...
+                                    double(dataNext(:,:,ind2(end)-size(dreg,3)));
+                            end
+                            ind2(end) = [];
+                        end
+                        dwrite(:,:,ceil(ind2/nplanes)) = dwrite(:,:,ceil(ind2/nplanes)) + ...
+                            weight .* double(dreg(:,:,ind2));
+                    end
+                end
+                fwrite(fidIntpol{ops.planesToProcess(planesToInterpolate(i))}, dwrite, class(data));
+            end
+        end
+        dataPrev = dreg(:,:,end-nplanes+1:end);
+        t1 = t1 + size(dreg,3);
+        iplane0 = iplane0 - nFr/ops.nchannels;
+    end
+    t2 = t2 + ceil(t1/nplanes)*nplanes;
+end


### PR DESCRIPTION
I adapted the non-rigid (block) registration, so that it can be used in addition to aligning movies across planes (in z-direction).
Most importantly, I changed (in blockReg2P) the way x- and y-range is determined. Instead of using xyValid (which crops the field of view across all planes), the block shifts (ops1{k}.DS) are used for each plane separately to determine x- and y-range. This will also affect non-rigid registrations that do not use alignment across planes. I think this is a better way, but please check.