### PR TITLE
Add storage manager to deal with folder structure

### DIFF
--- a/BaseStorageManager.m
+++ b/BaseStorageManager.m
@@ -1,0 +1,512 @@
+% An interface for providing access to raw files
+%
+% This interfaces hides details of storage schema. It is
+% provided as an abstract class. Implementation classes
+% are free to define different file schema.
+%
+% The interface is heavily influenced by original Suite2P
+% code, which supported a single file storage and didn't
+% abstract things. BaseStorageManager does not abstract all the things
+% that are possible to abstract. For example, it uses Suite2P format
+% for database entries. This is done in order to minimize the difference
+% between BaseStorageManager and original Suite2P.
+%
+% BaseStorageManager works with file sets, which can be organized
+% in partitions. In original Suite2P terms, partition is experiment.
+% Location of files and additional information is provided by db
+% entries, which are Matlab structures. BaseStorageManager uses
+% the following fields in each db entry:
+% *) mouseName      - cell array of strings, name/id of the animal.
+% *) date           - cell array of strings that represent dates, 'yyyy-mm-dd'.
+% *) experiments    - cell array of integer arrays. Must be provided!
+% *) expred         - array, points to partitions that contain red channel.
+% *) nchannels_red  - how many channels did the red block have in total (assumes red is last).
+% *) nchannels      - integer, number of channels. Default is 1.
+%
+% Please see the documentation of CortexLabStorageManager class for details of how a dbEntry
+% can be defined and added.
+%
+% General usage of BaseStorageManager is:
+% 1. Create an instance of BaseStorageManager implementation class.
+% 2. Describe things that are needed to be analyzed. This is
+%    done by adding 'database entries' to class. Each entry
+%    is a Matlab's structure. Implementation classes can use different
+%    structures.
+% 3. Query BaseStorageManager for data. Queries a performed by calling
+%    method getFile().
+% 4. When needed, use methods that construct file paths. Example of such
+%    method is registrationTiffPath().
+%
+classdef (Abstract) BaseStorageManager < handle
+    properties (Access=public)
+        options = struct()
+    end
+
+    properties (Access=protected)
+        % DB structure. It is used to store information
+        % about files to be analyzed.
+        db = []
+        % Index of a db entry that is currently in use.
+        currentEntry = 0
+        % Index of current tiff file to read from current db entry
+        currentFile = 0
+        % Index of current experiment/partition for current db entry
+        currentExperiment = 0
+
+        % vector of total number of files per db entry.
+        % Index is db entry. Value - number of files.
+        numFiles = []
+    end
+
+    methods (Access=public)
+        % Construct BaseStorageManager and initialized with options.
+        % Options is a structure with Suite2P options.
+        function this = BaseStorageManager(options)
+            this.options = options;
+        end
+
+        % Return number of channels for current partition in the current db entry.
+        function numChannels = getNumChannels(this)
+            numChannels = 0;
+            if ~this.isEntryInited
+                return;
+            end
+            numChannels = this.getOr('nchannels', 1);
+            redExperiments = this.getOr('expred', []);
+            isExperimentRed = ismember(this.currentExperiment, redExperiments);
+            if isExperimentRed
+                numChannels = this.getOr('nchannels_red');
+            end
+        end
+
+        % Add new entry to storage manager.
+        function addEntry(this, newEntry)
+            if ~isfield(newEntry, 'mouseName')
+                error('Your DB entry has no field mouseName. Please add it.');
+            end
+            % make mouseName a cell array
+            if ~iscell(newEntry.mouseName)
+                newEntry.mouseName = {newEntry.mouseName};
+            end
+
+            % make experiments a cell array
+            if ~iscell(newEntry.experiments)
+                newEntry.experiments = {newEntry.experiments};
+            end
+
+            if ~iscell(newEntry.date)
+                newEntry.date = {newEntry.date};
+            end
+
+            if isempty(this.db)
+                this.db = newEntry;
+            else
+                this.db(end+1) = newEntry;
+            end
+            [inited, newOptions] = this.initEntry(this.options, length(this.db));
+            this.options = newOptions;
+            if this.currentEntry == 0
+                if inited
+                    this.currentFile = 1;
+                    this.currentExperiment = 1;
+                    this.currentEntry = length(this.db);
+                else
+                    this.currentFile = 0;
+                    this.currentExperiment = 0;
+                end
+            end
+        end
+
+        % Return number of entries in storage manager.
+        function num = getNumEntries(this)
+            num = length(this.db);
+        end
+
+        % Remove all entries from storage manager.
+        function removeAllEntries(this)
+            this.db = [];
+            this.currentEntry = 0;
+            this.currentFile = 0;
+            this.currentExperiment = 0;
+        end
+
+        % Select entry with index entryInd as the current entry.
+        % Functions that access data interact with the current entry.
+        % This function allows to select current entry.
+        function selectEntry(this, entryInd)
+            if isempty(this.db)
+                error('Suite2P:notInited', 'Storage manager is not initialized, add an entry before calling selectEntry method.');
+            end
+
+            if entryInd < 1 || entryInd > length(this.db)
+                warning('New entry number is out of range. Should be in [1; %d], %d is given.', ...
+                    length(this.db), entryInd);
+                return;
+            end
+            this.currentEntry = entryInd;
+        end
+
+        % Reset current entry to state as if it had been just added to storage manager.
+        % After calling resetCurrentEntry, hasData() method will return logical 1 (true).
+        % This is useful if you want to iterate over the data in the current entry several times.
+        function resetCurrentEntry(this)
+            if this.currentEntry == 0
+                return;
+            end
+            if this.numFiles(this.currentEntry) > 0
+                this.currentFile = 1;
+                this.currentExperiment = 1;
+            end
+        end
+
+        %% The following methods are data-related
+
+        % Determine if data is available to read.
+        % Returns logical 1 (true) if there is data available
+        % to read from the current entry. If partition argument
+        % is specified, then returns logical 1 if that partition
+        % has data to read.
+        function has = hasData(this, partition)
+            has = false;
+            if ~this.isEntryInited
+                return;
+            end
+            if this.numFiles(this.currentEntry) == 0
+                return;
+            end
+
+            if nargin < 2
+                partition = [];
+            end
+            if ~isempty(partition)
+                if partition < 0 || partition > size(this.db(this.currentEntry).allTiffFiles, 1)
+                    % partition value is invalid
+                    return
+                end
+                if partition ~= this.currentExperiment
+                    this.currentExperiment = partition;
+                    this.currentFile = 1;
+                end
+
+                if isempty(this.db(this.currentEntry).allTiffFiles{partition, 2})
+                    return;
+                end
+            end
+
+            has = true;
+        end
+
+        % Return the very first file name for current trial.
+        % This method does not change the internal state of storage manager,
+        % i.e. multiple calls to it will return the same information.
+        %  USAGE
+        %   [name, info] = getFirstFile(sm, partition)
+        %   sm          - instance of storage manager class
+        %   partition   - positive integer. If provided,
+        %                 then returns the first file from that partition.
+        %                 Default is 1.
+        %   name        - full file path.
+        %   info        - file information, structure with fields:
+        %                 bytes     - file size in bytes.
+        %                 partition - partition index.
+        %
+        function [name, info] = getFirstFile(this, partition)
+            name = '';
+            if ~this.isEntryInited
+                return;
+            end
+
+            if nargin < 2
+                partition = 1;
+            end
+            if partition < 0 || partition > size(this.db(this.currentEntry).allTiffFiles, 1)
+                partition = 1;
+            end
+
+            name = this.db(this.currentEntry).allTiffFiles{partition, 2}{1};
+            if nargout > 1
+                info.bytes = this.db(this.currentEntry).allTiffFiles{partition, 3}(1);
+                info.partition = partition;
+            end
+        end
+
+        % Get file from current entry of storage manager.
+        % Returns file information from the current entry of storage manager.
+        % Subsequent calls to the getFile function continue getting files from
+        % the endpoint of the previous call.
+        % See method getFirstFile for the description of name and info variables.
+        function [name, info] = getFile(this)
+            name = '';
+            info = [];
+            if ~this.isEntryInited
+                return;
+            end
+
+            name = this.db(this.currentEntry).allTiffFiles{this.currentExperiment, 2}{this.currentFile};
+            if nargout > 1
+                info.bytes = this.db(this.currentEntry).allTiffFiles{this.currentExperiment, 3}(this.currentFile);
+                info.partition = this.currentExperiment;
+            end
+            this.increaseFileCounter();
+        end
+
+        % Get next file relative to the current file (last read file).
+        % This function does not change the internal state of storage manager,
+        % i.e. multiple/subsequent calls to getNextFile return the same information.
+        % See method getFirstFile for the description of name and info variables.
+        function [name, info] = getNextFile(this)
+            name = '';
+            info = [];
+            if ~this.isEntryInited
+                return;
+            end
+
+            numFiles = length(this.db(this.currentEntry).allTiffFiles{this.currentExperiment, 2}); %#ok<PROP>
+            if this.currentFile >= numFiles %#ok<PROP>
+                return;
+            end
+
+            fileInd = this.currentFile + 1;
+            name = this.db(this.currentEntry).allTiffFiles{this.currentExperiment, 2}{fileInd};
+            if nargout > 1
+                info.bytes = this.db(this.currentEntry).allTiffFiles{this.currentExperiment, 3}(fileInd);
+                info.partition = this.currentExperiment;
+            end
+        end
+
+        % Return number of files in current db entry or partition.
+        % If partition argument is omitted, then returns the total number of files
+        % for the current entry. If partition is provided, then returns number
+        % of files for that partition.
+        function num = getNumFiles(this, partition)
+            num = 0;
+            if this.currentEntry == 0
+                return;
+            end
+            if nargin == 2
+                num = length(this.db(this.currentEntry).allTiffFiles{partition, 2});
+            else
+                num = this.numFiles(this.currentEntry);
+                if isempty(num)
+                    num = 0;
+                end
+            end
+        end
+
+        % Return number of partitions in current entry.
+        function num = getNumPartitions(this)
+            num = 0;
+            if this.currentEntry == 0 || isempty(this.db)
+                return;
+            end
+            num = size(this.db(this.currentEntry).allTiffFiles, 1);
+        end
+
+        % Prepare partition for reading.
+        % Subsequent calls to the getFile function will return file
+        % from that partition.
+        function seekToPartition(this, partition)
+            if this.currentEntry == 0 || isempty(this.db)
+                return;
+            end
+            if partition < 0 || partition > size(this.db(this.currentEntry).allTiffFiles, 1)
+                warning('No valid partition %u, will fall back to the first one.', partition);
+                partition = 1;
+            end
+            this.currentExperiment = partition;
+            this.currentFile = 1;
+        end
+
+        % Return attribute or default value of current db entry or options.
+        % The function first checks if attribute with name field exists
+        % for the current db entry. If it does, then getOr() returns it's value.
+        % If it does not, then getOr() checks if field exists in storage
+        % manager's options.
+        %
+        %  USAGE
+        %   v = getOr(sm, field, value)
+        %   sm          Instance of storage manager
+        %   field       string, attribute name
+        %   value       If attribute is not present, then value
+        %               is returned.
+        %
+        function v = getOr(this, field, defaultValue)
+            if nargin < 3
+                defaultValue = [];
+            end
+            if this.currentEntry > 0
+                s = this.db(this.currentEntry);
+                [v, assigned] = this.getOrInternal(s, field, defaultValue);
+                if assigned
+                    return;
+                end
+            end
+            v = this.getOrInternal(this.options, field, defaultValue);
+        end
+    end
+
+    methods (Abstract)
+        % Determine if registration is done for the current entry.
+        tf = isRegistrationDone(this)
+
+        % Save registration options to disc.
+        saveRegistrationOptions(this, options)
+
+        % Load registration options from disc.
+        options = loadRegistrationOptions(this)
+
+        %%
+
+        % Return relative path from root where result files will be stored.
+        % If entryInd is not provided, then the current db entry is used.
+        % Root is a user-provided path where results should be stored.
+        folder = savePathFromRoot(this, entryInd)
+
+        % Return full file path to registration file for given plane and frame.
+        % Optional argument fileType can be set to 'red' in order to get
+        % file path for red channel.
+        filePath = registrationTiffPath(this, planeInd, frameInd, fileType)
+
+        % Return full file path to registration binary file on fast storage
+        % for a given plane.
+        % Fast storage is typically a local SSD. SSD have limited capacity and
+        % not suited for long-term storage of large binary files.
+        %  USAGE
+        %   filePath = registrationFileOnFastStorage(sm, planeInd, fileType)
+        %   sm          instance of storage manager.
+        %   planeInd    index of a plane for which file path is returned.
+        %   fileType    optional type of returned file, string.
+        %               Possible values are:
+        %               1. 'red' indicates that filePath contains path
+        %               to red channel.
+        %               2. 'interp' indicates that filePath contains path
+        %               to files with results of interpolation across frames.
+        filePath = registrationFileOnFastStorage(this, planeInd, fileType)
+
+        % Return full file path to registration binary file on slow storage
+        % for a given plane.
+        % Slow storage is a place where files get copied from fast storage.
+        %  USAGE
+        %   filePath = registrationFileOnSlowStorage(sm, planeInd, fileType)
+        %   sm          instance of storage manager.
+        %   planeInd    index of a plane for which file path is returned.
+        %   fileType    optional type of returned file, string.
+        %               Possible values are:
+        %               1. 'red' indicates that filePath contains path
+        %               to red channel.
+        %               2. 'interp' indicates that filePath contains path
+        %               to files with results of interpolation across frames.
+        filePath = registrationFileOnSlowStorage(this, planeInd, fileType)
+
+        % Return full file path for file of type fileType for plane with index planeInd.
+        % Different files can be produced per Tiff plane.
+        %  USAGE
+        %   filePath = getFileForPlane(this, fileType, planeInd)
+        %   sm          instance of storage manager.
+        %   fileType    One of the supported file types. For a complete list
+        %               see method supportedTypesForPlane.
+        %   planeInd    Index of a plane.
+        %   filePath    Full file path.
+        %
+        filePath = getFileForPlane(this, fileType, planeInd)
+
+        % Return description of supported file types per plane.
+        % Returns a Nx2 cell array. First column contains variables
+        % that can be passed to the function registrationFileOnSlowStorage as
+        % values for fileType argument. Second column contains human description.
+        % Example
+        % 1x2 cell array
+        %   {'svd'} {'File with computed SVD.'}
+        %
+        % If output variable is omitted, then the function prints out the information.
+        % Minimum supported types are: 'f', 'f_proc', 'neuropil', 'svd', 'svd_roi'.
+        descr = supportedTypesForPlane(this)
+
+        % Determines if provided fielType is supported as a valid file type for a Tiff plane.
+        tf = isTypeForPlaneSupported(this, fileType)
+    end
+
+    methods (Access=protected, Abstract=true)
+        % Initialize new db entry when it is added to storage manager.
+        % Arguments:
+        % options       storage manager options.
+        % entryInd      index of an entry that should be initialized.
+        % Output:
+        % inited        boolean flag indicating if entry has been initialized successfully.
+        % info          New version of options. Initialization function may change values or add
+        %               new fields to structure options. In order to keep track of it, a modified
+        %               version is returned via info.
+        %
+        [inited, info] = initEntry(this, options, entryInd)
+    end
+
+    methods (Access=protected)
+        % Increase internal file pointer.
+        function increaseFileCounter(this)
+            if ~this.isEntryInited
+                return;
+            end
+            this.currentFile = this.currentFile + 1;
+            if this.currentFile > length(this.db(this.currentEntry).allTiffFiles{this.currentExperiment, 2})
+                if this.currentExperiment == size(this.db(this.currentEntry).allTiffFiles, 1)
+                    this.currentExperiment = 0;
+                    this.currentFile = 0;
+                    return;
+                end
+
+                this.currentExperiment = this.currentExperiment + 1;
+                this.currentFile = 1;
+            end
+        end
+
+        % Determine if current db entry is initialized.
+        % Returns logical 1 (true) if entry is initialized.
+        function res = isEntryInited(this)
+            res = ~(this.currentEntry == 0 || this.currentFile == 0 || isempty(this.db));
+        end
+
+        function [v, assigned] = getOrInternal(~, s, field, default)
+            if nargin < 3
+                default = [];
+            end
+            assigned = false;
+
+            fieldExists = isfield(s, field);
+            if any(fieldExists)
+                assigned = true;
+                if iscellstr(field) || isstring(field)
+                    v = s.(field{find(fieldExists, 1)});
+                else
+                    v = s.(field);
+                end
+            else
+                v = default;
+            end
+        end
+
+        % Initialize values that could be inherited from a previous db entry.
+        % fieldNames is a cellArray of field names, which have their values
+        % inherited from previous db entry.
+        function dbEntry = initInheritedValues(this, dbEntry, fieldNames)
+            if ~iscell(fieldNames)
+                fieldNames = {fieldNames};
+            end
+            for i = 1:length(fieldNames)
+                fieldName = fieldNames{i};
+                if ~isfield(dbEntry, fieldName)
+                    if length(this.db) > 1 && this.currentEntry > 1
+                        if isfield(this.db(this.currentEntry-1), fieldName)
+                            % inherit from previous record
+                            this.db(this.currentEntry).(fieldName) = this.db(this.currentEntry-1).(fieldName);
+                            dbEntry.(fieldName) = this.db(this.currentEntry).(fieldName);
+                        else
+                            error('Value for field %s if not specified, animal %s', fieldName, dbEntry.mouseName{1});
+                        end
+                    end
+                end
+            end
+        end
+
+    end
+
+end

--- a/CortexLabStorageManager.m
+++ b/CortexLabStorageManager.m
@@ -1,0 +1,518 @@
+% Class that provides default Suite2P storage schema
+%
+% This is an implementation of BaseStorageManager class that provides the default Suite2P file
+% storage schema. In addition to fields that are used by BaseStorageManager, this classes uses
+% the following fields for db entries (can be provided via options as well):
+% rootStorage       - string. Path to folder where data is located. May contain a root path, which
+%                     is will be appended by '/mouseName/date/experiment' or it may point to
+%                     a folder, which contains Tiff files. rootStorage is used as is if it points
+%                     to folder with Tiff files. Must be provided for the first db entry!
+%                     If following entries doesn't specify rootStorage, then the value is inherited.
+%                     Thus, it is possible to assign a different storage folder to each db entry.
+% regFilePath       - string. (A former RegFileRoot from Suite2P). Specifies the location for
+%                     binary file, preferable on an SSD drive. Must be provided for the first
+%                     db entry!
+% resultsSavePath     - string. Path to the folder where result files will be stored. Based on
+%                     implementation, files might be stored not in resultsSavePath directly,
+%                     but in sub folders. If not provided, rootStorage is used.
+%                     CortexLabStorageManager creates a typical file structure:
+%                     rootStorage/mouseName/date/experiment
+% RegFileBinLocation  - string. Location of binary file on slow storage (i.e. on a remote storage).
+%                       If empty, then the registration file is not preserved between Suite2P runs.
+%                       The value is inherited through db entries.
+% RegFileTiffLocation - string. If not empty, saves registration results as tiff files in
+%                       that folder. Saving tiff files is slow.
+%                       The value is inherited through db entries.
+% temp_tiff         - string. Full path for a temporary tiff file. If specified, each remote tiff
+%                     file is copied to temp_tiff before being worked on.
+%                     The value is inherited through db entries.
+%
+classdef CortexLabStorageManager < BaseStorageManager
+    properties (Access=public)
+    end
+
+    properties (Access=private)
+    end
+
+    methods(Static=true)
+        % Convert db in original Suite2P format to new format understandable by BaseStorageManager.
+        % This function can be used to automatically convert db structure.
+        function newEntries = convertDbToStorageManager(db)
+            for i = 1:length(db)
+                oldEntry = db(i);
+
+                newEntries(i).mouseName = oldEntry.mouse_name;
+                newEntries(i).experiments = oldEntry.expts;
+                if isfield(oldEntry, 'RootDir')
+                    newEntries(i).rootStorage = oldEntry.RootDir;
+                    oldEntry = rmfield(oldEntry, 'RootDir');
+                end
+                oldEntry = rmfield(oldEntry, 'mouse_name');
+                oldEntry = rmfield(oldEntry, 'expts');
+
+                leftFields = fieldnames(oldEntry);
+                for j = 1:length(numel(leftFields))
+                    curField = leftFields{j};
+                    newEntries(i).(curField) = oldEntry.(curField);
+                end
+            end
+        end
+    end
+
+    methods
+        function this = CortexLabStorageManager(options)
+            this = this@BaseStorageManager(options);
+        end
+
+        function isDone = isRegistrationDone(this)
+            isDone = false;
+
+            options = this.loadRegistrationOptions();
+            if isempty(options)
+                return;
+            end
+
+            for i = 1:length(options)
+                if exist(options{i}.RegFile, 'file') == 0
+                    % file doesn't exist, we have nothing more to do here.
+                    return;
+                end
+            end
+
+            isDone = true;
+        end
+
+        function saveRegistrationOptions(this, options) %#ok<INUSD>
+            if this.currentEntry == 0
+                warning('Suite2P:notInited', 'Storage manager is not initialized, will not save registration file');
+                return;
+            end
+
+            filePath = this.registrationBinaryPath(this.db(this.currentEntry));
+            fileFolder = fileparts(filePath);
+            if ~exist(fileFolder, 'dir')
+                mkdir(fileFolder);
+            end
+            save(filePath, 'options');
+        end
+
+        function opt = loadRegistrationOptions(this)
+            if this.currentEntry == 0
+                error('Suite2P:notInited', 'Storage manager is not initialized, can not load registration file');
+            end
+            opt = [];
+            filePath = this.registrationBinaryPath(this.db(this.currentEntry));
+            if exist(filePath, 'file') == 0
+                return;
+            end
+
+            load(filePath, 'options');
+            opt = options; %#ok<*PROP>
+        end
+
+        function filePath = registrationTiffPath(this, planeInd, frameInd, fileType)
+            if nargin < 4
+                isRedChannel = false;
+            else
+                if strcmpi(fileType, 'red')
+                    isRedChannel = true;
+                else
+                    error('Unknown value of parameter ''type'' (given value is %s). See description of function registrationTiffPath.', fileType);
+                end
+            end
+            filePath = '';
+            if this.currentEntry == 0 || isempty(this.db)
+                return;
+            end
+            dbEntry = this.db(this.currentEntry);
+
+            [~, experimentDir] = fileparts(dbEntry.allTiffFiles{this.currentExperiment, 1});
+            folder = fullfile(this.getOr('RegFileTiffLocation'), dbEntry.mouseName{1}, ...
+                dbEntry.date{1}, experimentDir, sprintf('Plane%d', planeInd));
+            if ~exist(folder, 'dir')
+                mkdir(folder);
+            end
+
+            namePart = sprintf('%s_%s_%s_2P_plane%d_%d', dbEntry.date{1}, experimentDir, ...
+                dbEntry.mouseName{1}, planeInd, frameInd);
+            if isRedChannel
+                namePart = [namePart '_RED'];
+            end
+            fileName = [namePart '.tif'];
+            filePath = fullfile(folder, fileName);
+        end
+
+        function filePath = registrationFileOnFastStorage(this, planeInd, fileType)
+            isRedChannel = false;
+            isInterpolation = false;
+
+            if nargin < 3
+                isRedChannel = false;
+                isInterpolation = false;
+            else
+                if strcmpi(fileType, 'red')
+                    isRedChannel = true;
+                elseif strcmpi(fileType, 'interp')
+                    isInterpolation = true;
+                else
+                    error('Unknown value of parameter ''type'' (given value is %s). See description of function registrationFileOnFastStorage.', fileType);
+                end
+            end
+            filePath = '';
+            folder = this.registrationResultsFastFolder();
+            if isempty(folder) && ~isInterpolation
+                % return unless we have interpolation mode on. A different folder is
+                % used for interpolation.
+                return;
+            end
+            dbEntry = this.db(this.currentEntry);
+            experiments_str = sprintf('%d_', dbEntry.experiments{:});
+            experiments_str(end) = []; % remove last '_'
+            % experiments_str at this point is CharSubDirs from original Suite2P
+
+            if isRedChannel
+                fileName = sprintf('%s_%s_%s_plane%d_RED.bin', dbEntry.mouseName{1}, ...
+                    dbEntry.date{1}, experiments_str, planeInd);
+            else
+                fileName = sprintf('%s_%s_%s_plane%d.bin', dbEntry.mouseName{1}, ...
+                    dbEntry.date{1}, experiments_str, planeInd);
+            end
+            interpolationFolder = this.registrationResultsSlowFolder();
+            if isInterpolation
+                if isempty(interpolationFolder)
+                    filePath = '';
+                    return;
+                end
+                folder = fullfile(interpolationFolder, dbEntry.mouseName{1}, ...
+                    dbEntry.date{1}, experiments_str, 'interpolated');
+                if ~exist(folder, 'dir')
+                    mkdir(folder);
+                end
+            end
+
+            if ~exist(folder, 'dir')
+                mkdir(folder);
+            end
+            filePath = fullfile(folder, fileName);
+        end
+
+        function filePath = registrationFileOnSlowStorage(this, planeInd, fileType)
+            isRedChannel = false;
+            isInterpolation = false;
+
+            if nargin < 3
+                isRedChannel = false;
+                isInterpolation = false;
+            else
+                if strcmpi(fileType, 'red')
+                    isRedChannel = true;
+                elseif strcmpi(fileType, 'interp')
+                    isInterpolation = true;
+                else
+                    error('Unknown value of parameter ''type'' (given value is %s). See description of function registrationFileOnSlowStorage.', fileType);
+                end
+            end
+            filePath = '';
+            folder = this.registrationResultsSlowFolder();
+            if isempty(folder)
+                return;
+            end
+            dbEntry = this.db(this.currentEntry);
+            experiments_str = sprintf('%d_', dbEntry.experiments{:});
+            experiments_str(end) = []; % remove last '_'
+            % experiments_str at this point is CharSubDirs from original Suite2P
+
+            if isRedChannel
+                fileName = sprintf('%s_%s_%s_plane%d_RED.bin', dbEntry.mouseName{1}, ...
+                    dbEntry.date{1}, experiments_str, planeInd);
+            else
+                fileName = sprintf('%s_%s_%s_plane%d.bin', dbEntry.mouseName{1}, ...
+                    dbEntry.date{1}, experiments_str, planeInd);
+            end
+            interpolationFolder = folder;
+            if isInterpolation
+                if isempty(interpolationFolder)
+                    filePath = '';
+                    return;
+                end
+                folder = fullfile(interpolationFolder, dbEntry.mouseName{1}, ...
+                    dbEntry.date{1}, experiments_str, 'interpolated');
+            end
+
+            if ~exist(folder, 'dir')
+                mkdir(folder);
+            end
+            filePath = fullfile(folder, fileName);
+        end
+
+        function descr = supportedTypesForPlane(~)
+            descr = {};
+            descr = cat(1, descr, {'f', 'Results with dF'});
+            descr = cat(1, descr, {'f_proc', 'Results with dF'});
+            descr = cat(1, descr, {'neuropil', 'Neuropil file'});
+            descr = cat(1, descr, {'svd', 'file with computed SVD'});
+            descr = cat(1, descr, {'svd_roi', 'File with computed SVD for ROI'});
+            if nargout == 0
+                fprintf('Supported file type per Tiff plane\n');
+                for i = 1:size(descr, 1)
+                    fprintf('%-20s - %s\n', descr{i, 1:2})
+                end
+            end
+        end
+
+        function isSupported = isTypeForPlaneSupported(this, fileType)
+            descr = this.supportedTypesForPlane();
+            isSupported = any(ismember(descr(:, 1), fileType));
+        end
+
+        function filePath = getFileForPlane(this, fileType, planeInd)
+            if ~this.isTypeForPlaneSupported(fileType)
+                error('Given file type is not supported. See function supportedTypesForPlane for a list of supported types.');
+            end
+            filePath = '';
+            if isempty(this.db) || this.currentEntry == 0
+                return;
+            end
+            dbEntry = this.db(this.currentEntry);
+
+            folder = this.savePathFromRoot();
+            switch lower(fileType)
+                case 'f'
+                    fileName = sprintf('F_%s_%s_plane%d.mat', dbEntry.mouseName{1}, dbEntry.date{1}, planeInd);
+
+                case 'f_proc'
+                    fileName = sprintf('F_%s_%s_plane%d_proc.mat', dbEntry.mouseName{1}, dbEntry.date{1}, planeInd);
+
+                case 'svd'
+                    fileName = sprintf('SVD_%s_%s_plane%d.mat', dbEntry.mouseName{1}, dbEntry.date{1}, planeInd);
+
+                case 'svd_roi'
+                    fileName = sprintf('SVDroi_%s_%s_plane%d.mat', dbEntry.mouseName{1}, dbEntry.date{1}, planeInd);
+            end
+
+            filePath = fullfile(folder, fileName);
+        end
+
+        % Return path where result files will be stored.
+        % Part of the interface
+        function name = savePathFromRoot(this, entryInd)
+            name = '';
+            if isempty(this.db)
+                error('Suite2P:notInited', 'Storage manager is not initialized. Please add a db entry first.');
+            end
+
+            if nargin < 2
+                entryInd = this.currentEntry;
+                if this.currentEntry == 0
+                    warning('Suite2P:notInited', 'Storage manager is not initialized.');
+                    return;
+                end
+            end
+
+            if entryInd < 1 || entryInd > length(this.db)
+                error('Suite2P:arg', 'Value for argument entryInd is out of range. Possible range is [1; %d], value given is %d\n', length(this.db), entryInd);
+            end
+            dbEntry = this.db(entryInd);
+            name = sprintf('%d_', dbEntry.experiments{:});
+            name(end) = []; % remove last '_'
+            % name at this point is CharSubDirs from original Suite2P
+
+            if ~isfield(dbEntry, 'resultsSavePath') || isempty(dbEntry.resultsSavePath)
+                folder = dbEntry.rootStorage;
+            else
+                folder = dbEntry.resultsSavePath;
+            end
+
+            name = fullfile(folder, dbEntry.mouseName{1}, ...
+                dbEntry.date{1}, name);
+            if ~exist(name, 'dir')
+                mkdir(name);
+            end
+        end
+
+    end
+
+    methods (Access=protected)
+        function checkRequiredFields(this, options, entryInd)
+            % let's check that all necessary db fields are specified.
+            required = {'regFilePath', 'rootStorage', 'experiments'};
+            for i = 1:length(required)
+                fieldName = required{i};
+                [v1, assigned] = this.getOrInternal(this.db(entryInd), fieldName, []);
+                [v2, assigned2] = this.getOrInternal(options, fieldName, []);
+                if assigned
+                    v = v1;
+                else
+                    v = v2;
+                end
+                notAssigned = ~(assigned || assigned2);
+                if notAssigned || isempty(v)
+                    error('Suite2P:incompleteDb', 'Can not add db entry %d (%s) as required field ''%s'' is missing. Please add it in order to continue.', entryInd, this.db(entryInd).mouseName{1}, fieldName);
+                end
+            end
+        end
+
+        % Initialize current entry with given options. Options are not necessary db related.
+        % For more details see initEntry in BaseStorageManager.
+        function [inited, info] = initEntry(this, options, entryInd)
+            dbEntry = this.db(entryInd);
+            %tifPaths = {};
+            % cell array that contains list of cell files. Has
+            % the same length as tifPaths. Each
+            % Resembles fsroot from original Suite2P
+            allTiffFiles = {};
+            entryNumFiles = 0;
+
+            dbEntry = this.initInheritedValues(dbEntry, {'rootStorage', 'RegFileBinLocation', 'RegFileTiffLocation', ...
+                'temp_tiff'});
+            this.checkRequiredFields(options, entryInd);
+
+            rootStorage = dbEntry.rootStorage;
+            tiffFiles = dir(fullfile(rootStorage, '*.tif*'));
+            directPath = ~isempty(tiffFiles);
+
+            nSessions = length(dbEntry.mouseName);
+            for i = 1:nSessions
+                curExperiments = dbEntry.experiments{i};
+                if isempty(curExperiments) && directPath
+                    curExperiments = [0]; % the value is not important
+                end
+
+                %curSubDirs
+                for iExp = 1:length(curExperiments)
+                    experiment_string = num2str(curExperiments(iExp));
+                    sessionRelativePath = fullfile(dbEntry.mouseName{i}, dbEntry.date{i}, experiment_string);
+                    if directPath
+                        tiffFolder = rootStorage;
+                    else
+                        tiffFolder = fullfile(rootStorage, sessionRelativePath);
+                    end
+
+                    % Find both .tif and .tiff files
+                    files1 = dir(fullfile(tiffFolder, '*.tif'));
+                    files2 = dir(fullfile(tiffFolder, '*.tiff'));
+                    tiffFiles = cat(1, files1, files2);
+                    allFileSizes = [tiffFiles(:).bytes];
+
+                    [tiffFiles, sortIndex] = sort_nat({tiffFiles(:).name});
+                    allFileSizes = allFileSizes(sortIndex);
+                    tiffFiles = cellfun(@(x) fullfile(tiffFolder, x), tiffFiles, 'uniformoutput', false);
+                    allTiffFiles = cat(1, allTiffFiles, {tiffFolder, tiffFiles, allFileSizes});
+                    entryNumFiles = entryNumFiles + length(tiffFiles);
+                end
+            end
+            this.numFiles(entryInd) = entryNumFiles;
+
+            options.nplanes = this.getOr('nplanes', 1);
+            options.nchannels = this.getOr('nchannels', 1);
+            options.readTiffHeader = this.getOr('readTiffHeader', true);
+
+            if options.readTiffHeader
+                try
+                    [~, header] = loadFramesBuff(allTiffFiles{1, 2}(1), 1, 1, 1);
+                    hh = header{1};
+                    verStr = 'SI.VERSION_MAJOR = ''2016b''';
+                    if contains(hh, verStr) % For scanImage 2016b
+                        str = hh(strfind(hh, 'channelSave = '):end);
+                        ind = strfind(str, 'SI');
+                        ch = str2double(str(15:ind(1)-1));
+                        options.nchannels = length(ch);
+
+                        fastZEnable = sscanf(hh(strfind(hh, 'hFastZ.enable = '):end), 'hFastZ.enable = %s');
+                        fastZEnable = strcmpi(fastZEnable, 'true');
+                        fastZDiscardFlybackFrames = sscanf(hh(strfind(hh, 'hFastZ.discardFlybackFrames = '):end), 'hFastZ.discardFlybackFrames = %s');
+                        fastZDiscardFlybackFrames = strcmpi(fastZDiscardFlybackFrames, 'true');
+                        stackNumSlices = sscanf(hh(strfind(hh, 'hStackManager.numSlices = '):end), 'hStackManager.numSlices = %d');
+
+                        if fastZEnable
+                            options.nplanes = stackNumSlices + fastZDiscardFlybackFrames;
+                        end
+
+                        str = hh(strfind(hh, 'scanZoomFactor = '):end);
+                        ind = strfind(str, 'SI');
+                        options.zoomMicro = str2double(str(18 : ind(1)-1));
+                        options.imageRate = sscanf(hh(strfind(hh, 'scanFrameRate = '):end), 'scanFrameRate = %f');
+
+                        % if isfield(db, 'expred') && ~isempty(db.expred) && ...
+                        %         (~isfield(db, 'nchannels_red') || isempty(db.nchannels_red))
+                        %     [~, header] = loadFramesBuff(options.fsred(1).name, 1, 1, 1);
+                        %     hh=header{1};
+                        %     str = hh(strfind(hh, 'channelSave = '):end);
+                        %     ind = strfind(str, 'SI');
+                        %     ch = str2num(str(15 : ind(1)-1));
+                        %     options.nchannels_red = length(ch);
+                        % end
+                    end
+
+                    % Old scanimage
+                    str = hh(strfind(hh, 'channelsSave = '):end);
+                    ind = strfind(str, 'scanimage');
+                    ch = str2double(str(16 : ind(1)-1));
+                    options.nchannels = length(ch);
+
+                    fastZEnable = sscanf(hh(strfind(hh, 'fastZEnable = '):end), 'fastZEnable = %d');
+                    fastZDiscardFlybackFrames = sscanf(hh(strfind(hh, 'fastZDiscardFlybackFrames = '):end), 'fastZDiscardFlybackFrames = %d');
+                    if isempty(fastZDiscardFlybackFrames)
+                        fastZDiscardFlybackFrames = 0;
+                    end
+                    stackNumSlices = sscanf(hh(strfind(hh, 'stackNumSlices = '):end), 'stackNumSlices = %d');
+
+                    options.nplanes = 1;
+                    if fastZEnable
+                        options.nplanes = stackNumSlices+fastZDiscardFlybackFrames;
+                    end
+
+                    str = hh(strfind(hh, 'scanZoomFactor = '):end);
+                    ind = strfind(str, 'scanimage');
+                    options.zoomMicro = str2double(str(18 : ind(1)-1));
+
+                    options.imageRate = sscanf(hh(strfind(hh, 'scanFrameRate = '):end), 'scanFrameRate = %f');
+                catch
+                    fprintf('There was an exception during loading of tiff file header. Probably your files do not have headers.\nFile was: %s\n', allTiffFiles{1, 2}(1));
+                end
+            end % end read tiff header
+
+            if isfield(options, 'zoomMicro')
+                options.zoom = getOr(options, 'zoom', options.zoomMicro);
+            else
+                options.zoom = getOr(options, 'zoom', 1);
+            end
+
+            options.planesToProcess = 1:options.nplanes;
+
+            options.resultsSavePath = this.savePathFromRoot(entryInd);
+
+            info = options;
+            this.options = options;
+
+            this.db(entryInd).allTiffFiles = allTiffFiles;
+            inited = ~isempty(allTiffFiles);
+        end
+    end
+
+    methods (Access=private)
+        function folder = registrationResultsFastFolder(this)
+            %folder = this.getOr('RegFileRoot', '');
+            folder = this.getOr('regFilePath', '');
+        end
+
+        function folder = registrationResultsSlowFolder(this)
+            folder = this.getOr('RegFileBinLocation', '');
+        end
+
+        function filePath = registrationBinaryPath(this, options)
+            filePath = '';
+            fileName = this.registrationBinaryName(options);
+            folder = this.savePathFromRoot();
+            if isempty(folder)
+                return;
+            end
+            filePath = fullfile(folder, fileName);
+            filePath = strrep(filePath, '\', '/');
+        end
+
+        function name = registrationBinaryName(~, options)
+            name = sprintf('regops_%s_%s.mat', options.mouseName{1}, options.date{1});
+        end
+    end
+end

--- a/CortexLabStorageManager.m
+++ b/CortexLabStorageManager.m
@@ -88,7 +88,7 @@ classdef CortexLabStorageManager < BaseStorageManager
                 return;
             end
 
-            filePath = this.registrationBinaryPath(this.db(this.currentEntry));
+            filePath = this.registrationBinaryPath(this.db{this.currentEntry});
             fileFolder = fileparts(filePath);
             if ~exist(fileFolder, 'dir')
                 mkdir(fileFolder);
@@ -101,7 +101,7 @@ classdef CortexLabStorageManager < BaseStorageManager
                 error('Suite2P:notInited', 'Storage manager is not initialized, can not load registration file');
             end
             opt = [];
-            filePath = this.registrationBinaryPath(this.db(this.currentEntry));
+            filePath = this.registrationBinaryPath(this.db{this.currentEntry});
             if exist(filePath, 'file') == 0
                 return;
             end
@@ -124,7 +124,7 @@ classdef CortexLabStorageManager < BaseStorageManager
             if this.currentEntry == 0 || isempty(this.db)
                 return;
             end
-            dbEntry = this.db(this.currentEntry);
+            dbEntry = this.db{this.currentEntry};
 
             [~, experimentDir] = fileparts(dbEntry.allTiffFiles{this.currentExperiment, 1});
             folder = fullfile(this.getOr('RegFileTiffLocation'), dbEntry.mouseName{1}, ...
@@ -155,7 +155,7 @@ classdef CortexLabStorageManager < BaseStorageManager
                 elseif strcmpi(fileType, 'interp')
                     isInterpolation = true;
                 else
-                    error('Unknown value of parameter ''type'' (given value is %s). See description of function registrationFileOnFastStorage.', fileType);
+                    error('Suite2P:arg', 'Unknown value of parameter ''type'' (given value is ''%s''). See description of function registrationFileOnFastStorage.', fileType);
                 end
             end
             filePath = '';
@@ -165,7 +165,7 @@ classdef CortexLabStorageManager < BaseStorageManager
                 % used for interpolation.
                 return;
             end
-            dbEntry = this.db(this.currentEntry);
+            dbEntry = this.db{this.currentEntry};
             experiments_str = sprintf('%d_', dbEntry.experiments{:});
             experiments_str(end) = []; % remove last '_'
             % experiments_str at this point is CharSubDirs from original Suite2P
@@ -217,7 +217,7 @@ classdef CortexLabStorageManager < BaseStorageManager
             if isempty(folder)
                 return;
             end
-            dbEntry = this.db(this.currentEntry);
+            dbEntry = this.db{this.currentEntry};
             experiments_str = sprintf('%d_', dbEntry.experiments{:});
             experiments_str(end) = []; % remove last '_'
             % experiments_str at this point is CharSubDirs from original Suite2P
@@ -273,7 +273,7 @@ classdef CortexLabStorageManager < BaseStorageManager
             if isempty(this.db) || this.currentEntry == 0
                 return;
             end
-            dbEntry = this.db(this.currentEntry);
+            dbEntry = this.db{this.currentEntry};
 
             folder = this.savePathFromRoot();
             switch lower(fileType)
@@ -312,7 +312,7 @@ classdef CortexLabStorageManager < BaseStorageManager
             if entryInd < 1 || entryInd > length(this.db)
                 error('Suite2P:arg', 'Value for argument entryInd is out of range. Possible range is [1; %d], value given is %d\n', length(this.db), entryInd);
             end
-            dbEntry = this.db(entryInd);
+            dbEntry = this.db{entryInd};
             name = sprintf('%d_', dbEntry.experiments{:});
             name(end) = []; % remove last '_'
             % name at this point is CharSubDirs from original Suite2P
@@ -338,7 +338,7 @@ classdef CortexLabStorageManager < BaseStorageManager
             required = {'regFilePath', 'rootStorage', 'experiments'};
             for i = 1:length(required)
                 fieldName = required{i};
-                [v1, assigned] = this.getOrInternal(this.db(entryInd), fieldName, []);
+                [v1, assigned] = this.getOrInternal(this.db{entryInd}, fieldName, []);
                 [v2, assigned2] = this.getOrInternal(options, fieldName, []);
                 if assigned
                     v = v1;
@@ -347,7 +347,7 @@ classdef CortexLabStorageManager < BaseStorageManager
                 end
                 notAssigned = ~(assigned || assigned2);
                 if notAssigned || isempty(v)
-                    error('Suite2P:incompleteDb', 'Can not add db entry %d (%s) as required field ''%s'' is missing. Please add it in order to continue.', entryInd, this.db(entryInd).mouseName{1}, fieldName);
+                    error('Suite2P:incompleteDb', 'Can not add db entry %d (%s) as required field ''%s'' is missing. Please add it in order to continue.', entryInd, this.db{entryInd}.mouseName{1}, fieldName);
                 end
             end
         end
@@ -355,7 +355,7 @@ classdef CortexLabStorageManager < BaseStorageManager
         % Initialize current entry with given options. Options are not necessary db related.
         % For more details see initEntry in BaseStorageManager.
         function [inited, info] = initEntry(this, options, entryInd)
-            dbEntry = this.db(entryInd);
+            dbEntry = this.db{entryInd};
             %tifPaths = {};
             % cell array that contains list of cell files. Has
             % the same length as tifPaths. Each
@@ -485,8 +485,8 @@ classdef CortexLabStorageManager < BaseStorageManager
             info = options;
             this.options = options;
 
-            this.db(entryInd).allTiffFiles = allTiffFiles;
-            inited = ~isempty(allTiffFiles);
+            this.db{entryInd}.allTiffFiles = allTiffFiles;
+            inited = ~isempty(allTiffFiles) && ~isempty(allTiffFiles{1, 2});
         end
     end
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Suite2p: fast, accurate and complete two-photon pipeline
 
-Registration, cell detection, spike extraction and visualization GUI. 
+Registration, cell detection, spike extraction and visualization GUI.
 
 Algorithmic details in [http://biorxiv.org/content/early/2016/06/30/061507](http://biorxiv.org/content/early/2016/06/30/061507).
 
@@ -17,54 +17,65 @@ This is a complete, automated pipeline for processing two-photon Calcium imaging
 
 1. **X-Y subpixel registration**: using a modification of the phase correlation algorithm and subpixel translation in the FFT domain. If a GPU is available, this completes in 20 minutes per 1h of recordings at 30Hz and 512x512 resolution.
 
-1. **SVD decomposition**: this provides the input to cell detection and accelerates the algorithm. 
+1. **SVD decomposition**: this provides the input to cell detection and accelerates the algorithm.
 
 1. **Cell detection**: using clustering methods in a low-dimensional space. The clustering algorithm provides a positive mask for each ROI identified, and allows for overlaps between masks. There is also an option to perform automated red cell detection.
 
-1. **Signal extraction**: by default, all overlapping pixels are discarded when computing the signal inside each ROI, to avoid using "demixing" approaches, which can be biased. The neuropil signal is also computed independently for each ROI, as a weighted pixel average, pooling from a large area around each ROI, but excluding all pixels assigned to ROIs during cell detection. 
+1. **Signal extraction**: by default, all overlapping pixels are discarded when computing the signal inside each ROI, to avoid using "demixing" approaches, which can be biased. The neuropil signal is also computed independently for each ROI, as a weighted pixel average, pooling from a large area around each ROI, but excluding all pixels assigned to ROIs during cell detection.
 
-1. **Spike deconvolution**: cell and neuropil traces are further processed to obtain an estimate of spike times and spike "amplitudes". The amplitudes are proportional to the number of spikes in a burst/bin. Even under low SNR conditions, where transients might be hard to identify, the deconvolution is still useful for temporally-localizing responses. The cell traces are baselined using the minimum of the (overly) smoothed trace. 
+1. **Spike deconvolution**: cell and neuropil traces are further processed to obtain an estimate of spike times and spike "amplitudes". The amplitudes are proportional to the number of spikes in a burst/bin. Even under low SNR conditions, where transients might be hard to identify, the deconvolution is still useful for temporally-localizing responses. The cell traces are baselined using the minimum of the (overly) smoothed trace.
 
-1. **Neuropil subtraction**: coefficient is estimated iteratively together with spike deconvolution to minimize the residual of spike deconvolution. The user is encouraged to also try varying this coefficient, to make sure that any scientific results do not depend crucially on it. 
+1. **Neuropil subtraction**: coefficient is estimated iteratively together with spike deconvolution to minimize the residual of spike deconvolution. The user is encouraged to also try varying this coefficient, to make sure that any scientific results do not depend crucially on it.
 
 1. **Automatic and manual curation**: the output of the cell detection algorithm can be visualized and further refined using the included GUI. The GUI is designed to make cell sorting a fun and enjoyable experience. It also includes an automatic classifier that gradually refines itself based on the manual labelling provided by the user. This allows the automated classifier to adapt for different types of data, acquired under different conditions. (*README FOR GUI AT https://github.com/cortex-lab/Suite2P/blob/master/gui2P/README.md*)
 
 
 # II. Getting started
 
-The toolbox runs in Matlab and currently only supports tiff file inputs. To begin using the toolbox, you will need to make local copies (in a separate folder) of two included files: master_file and make_db. It is important that you make local copies of these files, otherwise updating the repository will overwrite them (and you can lose your files). The make_db file assembles a database of experiments that you would like to be processed in batch. It also adds per-session specific information that the algorithm requires such as the number of imaged planes and channels. The master_file sets general processing options that are applied to all sessions included in make_db, UNLESS the option is over-ridden in the make_db file. 
+The toolbox runs in Matlab and currently only supports tiff file inputs. To begin using the toolbox, you will need to make local copies (in a separate folder) of two included files: `master_file` and `make_db`. It is important that you make local copies of these files, otherwise updating the repository will overwrite them (and you can lose your files). The `make_db_example.m` file (found in `onfigFiles` folder) assembles a database of experiments that you would like to be processed in batch. It also adds per-session specific information that the algorithm requires such as the number of imaged planes and channels. The `master_file_example.m` sets general processing options that are applied to all sessions included in `make_db`, UNLESS the option is over-ridden in the `make_db` file.
 
 ### Example database entry
-Look into make_db_example for more detailed examples.
+Look into `make_db_example` for more detailed examples.
 
-The following is a typical database entry in the local make_db file, which can be modelled after make_db_example. The folder structure assumed is RootStorage/mouse_name/date/expts(k) for all entries in expts(k).
+The toolbox supports different folder structure for accessing the files. The default structure is
+assumed as `rootStorage/mouseName/date/experiments(k)`. A *storage manager* is responsible to know
+folder structure. Storage manager is an interface provided in file `BaseStorageManager.m`.
+The default implementation is in file `CortexLabStorageManager.m`.
+
+The following is a typical database entry for CortexLabStorageManager in the local `make_db` file,
+which can be modelled after `make_db_example`.
 ```
-i = i+1; 
-db(i).mouse_name = 'M150329_MP009'; 
-db(i).date = '2015-04-27'; 
-db(i).expts = [5 6]; % which experiments to process together
+i = i+1;
+db(i).mouseName = 'M150329_MP009';
+db(i).date = '2015-04-27';
+db(i).experiments = [5 6]; % which experiments to process together
+db(i).rootStorage = 'F:\workspace\dataFolder'; % path to where data is located
 ```
-Other (hidden) options are described in make_db_example.m, and at the top of run_pipeline.m (set to reasonable defaults).
+Other (hidden) options are described in `make_db_example.m`, and at the top of `run_pipeline.m` (set to reasonable defaults).
+
+A storage manager is new to Suite2P and not all files are using it. However, the general pipeline
+(i.e. `run_pipeline.m`) is ready.
 
 ### Running the pipeline
-Change paths in master_file to the paths to your local toolbox and to your data. Then run this function. The master_file creates the ops0 variable and the db0 variable, and runs the main pipeline:
+Change paths in `master_file` to the paths to your local toolbox and to your data. Then run this function.
+The `master_file` creates the an instance of storage manager (`sm`), and runs the main pipeline:
 
 ```
-run_pipeline(db, ops);
+run_pipeline(sm);
 ```
 
 ### Spike deconvolution
 
-For spike deconvolution, you need to download the OASIS github (https://github.com/zhoupc/OASIS_matlab) and add the path to this folder on your computer to the top of your master_file 
+For spike deconvolution, you need to download the OASIS github (https://github.com/zhoupc/OASIS_matlab) and add the path to this folder on your computer to the top of your master_file
 ```
 addpath(genpath('pathtoOASIS')))
 ```
 To run spike deconvolution (after running the pipeline), run
 ```
-add_deconvolution(ops0, db);
+add_deconvolution(sm);
 ```
 
-For L0 spike deconvolution, you need to run mex -largeArrayDims SpikeDetection/deconvL0.c (or .cpp under Linux/Mac). If you're on Windows, you will need to install Visual Studio Community in order to mex files in matlab. To choose this deconvolution method, set  
+For L0 spike deconvolution, you need to run mex -largeArrayDims SpikeDetection/deconvL0.c (or .cpp under Linux/Mac). If you're on Windows, you will need to install Visual Studio Community in order to mex files in matlab. To choose this deconvolution method, set
 ```
 ops0.deconvType = 'L0';
 ```
@@ -73,31 +84,34 @@ See this paper comparing spike deconvolution methods for more information on cho
 You can also run spike deconvolution without running the entire pipeline by calling wrapperDECONV(ops,F,N), where F and N are the fluorescence and neuropil traces respectively, while ops specifies some deconvolution parameters like sampling rate and sensory decay timescale. See the function help for more information.
 
 ----------
-Below we describe the outputs of the pipeline first, and then describe the options for setting it up, and customizing it. Importantly, almost all options have pre-specified defaults. Any options specified in `master_file` in ops0 overrides these defaults. Furthermore, any option specified in the `make_db` file (experiment specific) overrides both the defaults and the options set in master_file. This allows for flexibility in processing different experiments with different options. The only critical option that you'll need to set is ops0.diameter, or db(N).diameter. This gives the algorithm the scale of the recording, and the size of ROIs you are trying to extract. We recommend as a first run to try the pipeline after setting the diameter option. Depending on the results, you can come back and try changing some of the other options.  
+Below we describe the outputs of the pipeline first, and then describe the options for setting it up, and customizing it. Importantly, almost all options have pre-specified defaults. Any options specified in `master_file` in ops0 overrides these defaults. Furthermore, any option specified in the `make_db` file (experiment specific) overrides both the defaults and the options set in `master_file`. This allows for flexibility in processing different experiments with different options. The only critical option that you'll need to set is ops0.diameter, or db(N).diameter. This gives the algorithm the scale of the recording, and the size of ROIs you are trying to extract. We recommend as a first run to try the pipeline after setting the diameter option. Depending on the results, you can come back and try changing some of the other options.
 
-Note: some of the options are not specified in either the example `master_file` or the example make_db file. These are usually more specialized features.
+Note: some of the options are not specified in either the example `master_file` or the example
+`make_db` file. These are usually more specialized features.
 
 # III. Outputs.
 
-The output is a struct called dat which is saved into a mat file in ResultsSavePath using the same subfolder structure, under a name formatted like `F_M150329_MP009_2015-04-29_plane1`. It contains all the information collected throughout the processing, and contains the ROI and neuropil traces in Fcell and FcellNeu, and whether each ROI j is a cell or not in stat(j).iscell. stat(j) contains information about each ROI j and can be used to recover the corresponding pixels for each ROI in stat.ipix. The centroid of the ROI is specified in stat as well. Here is a summary of where the important results are:
+The location of the output files will depend on the particular storage manager you used for the analysis.
+Below we describe the output format and file locations for default CortexLabStorageManager.
 
-cell traces are in `Fcell`  
-neuropil traces are in `FcellNeu`
+The output is a struct called `dat` which is saved into a mat file in `resultsSavePath` using the same subfolder structure, under a name formatted like `F_M150329_MP009_2015-04-29_plane1`. It contains all the information collected throughout the processing, and contains the ROI and neuropil traces in `Fcell` and `FcellNeu`, and whether each ROI `j` is a cell or not in `stat(j).iscell`. `stat(j)` contains information about each ROI `j` and can be used to recover the corresponding pixels for each ROI in `stat.ipix`. The centroid of the ROI is specified in `stat` as well. Here is a summary of where the important results are:
 
-deconvolved traces are in `sp`
+* cell traces are in `Fcell`
+* neuropil traces are in `FcellNeu`
+* deconvolved traces are in `sp`
 
-Each cell of the above structures is a different experiment from db.expts.
-manual, GUI overwritten "iscell" labels are in `stat.iscell`  
- 
-stat(icell) contains all other information:  
-* _iscell_: automated label, based on anatomy  
+Each cell of the above structures is a different experiment from `db.experiments`.
+manual, GUI overwritten "iscell" labels are in `stat.iscell`
+
+`stat(icell)` contains all other information:
+* _iscell_: automated label, based on anatomy
 * _neuropilCoefficient_: multiplicative coefficient on the neuropil signal
-* _xpix, ypix_: x and y indices of pixels belonging to this max. These index into the valid part of the image (defined by ops.yrange, ops.xrange).   
-* _ipix_: linearized indices ((ypix, xpix) --> ypix + (xpix-1) x Ly) of pixels belonging to this mask.   
-* _isoverlap_: whether the pixels overlap with other masks.     
-* _lam, lambda_: mask coefficients for the corresponding pixels. lambda is the same as lam, but normalized to 1.   
-* _med_: median of y and x pixels in the ROI (indices for the valid part of the image, defined by ops.yrange, ops.xrange).   
-* _blockstarts_: the cumulative number of frames per block. Clould be useful for concatenating experiments correctly (some planes will have fewer frames/block). 
+* _xpix, ypix_: x and y indices of pixels belonging to this max. These index into the valid part of the image (defined by ops.yrange, ops.xrange).
+* _ipix_: linearized indices ((ypix, xpix) --> ypix + (xpix-1) x Ly) of pixels belonging to this mask.
+* _isoverlap_: whether the pixels overlap with other masks.
+* _lam, lambda_: mask coefficients for the corresponding pixels. lambda is the same as lam, but normalized to 1.
+* _med_: median of y and x pixels in the ROI (indices for the valid part of the image, defined by ops.yrange, ops.xrange).
+* _blockstarts_: the cumulative number of frames per block. Clould be useful for concatenating experiments correctly (some planes will have fewer frames/block).
 * _footprint, mrs, mrs0, cmpct, aspec_ratio, ellipse, mimgProj, skew, std, maxMinusMed, top5pcMinusMed_: these are used by the automated classifier to label an ROI as cell or not. see section IX for details.
 
 There are fields for red cell detection too (see the section on **Identifying red cells**)
@@ -109,26 +123,34 @@ The settings for the registration and the mean image are also output in the `ops
 
 # IV. Input-output file paths
 
-* _RootStorage_ --- the root location where the raw tiff files are  stored.
-* _RegFileRoot_ --- location on local disk where to keep the registered movies in binary format. This will be loaded several times so it should ideally be an SSD drive. (to view registered movies use script "view_registered_binaries.m" in main folder)
-* _ResultsSavePath_ --- where to save the final results. 
-* _DeleteBin_ --- deletes the binary file created to store the registered movies
+All paths are provided per db entry. Refer to documentation of `BaseStorageManager` and `CortexLabStorageManager`.
+
+* _rootStorage_ --- the root location where the raw tiff files are stored.
+* _regFilePath_ --- location on local disk where to keep the registered movies in binary format.
+                    This will be loaded several times so it should ideally be an SSD drive. (to view
+                    registered movies use script `view_registered_binaries.m` in main folder).
+                    If `DeleteBin` is set to logical 1 (true), then registration file is going to be
+                    deleted from `regFilePath`.
+* _resultsSavePath_ --- where to save the final results. Note that depending on other options not all
+					    files end up in `resultsSavePath`.
+* _DeleteBin_ --- deletes the binary file created to store the registered movies.
 * _RegFileTiffLocation_ --- where to save registered tiffs (if empty, does not save)
-**if you want to save red tiffs, then specify ops.RegFileTiffLocation and set ops.REDbinary = 1**
+**if you want to save red tiffs, then specify db(i).RegFileTiffLocation and set ops.REDbinary = 1**
 
-_ResultsSavePath_ is completed with separate subfolders per animal and experiment, specified in the make_db file. Your data should be stored under a file tree of the form
-
+_ResultsSavePath_ is completed with separate subfolders per animal and experiment, specified
+in the `make_db` file. Your data should be stored under a file tree of the form
+```
 \RootStorage\mouse_name\session\block\*.tif(f)
-
-If you don't want to use this folder structure, see the make_db_example file for alternatives. The make_db_example file also shows how to group together tiffs from different experiments (i.e. different subfolders within this folder structure).
-
-The output is a struct called dat which is saved into a mat file in ResultsSavePath using the same subfolder structure, under a name formatted like F_M150329_MP009_2015-04-29_plane1. It contains all the information collected throughout the processing, and contains the fluorescence traces in dat.Fcell and whether a given ROI is a cell or not in dat.stat(N).iscell. dat.stat contains information about each ROI and can be used to recover the corresponding pixels for each ROI N in dat.stat(N).ipix. The centroid of the ROI N is specified in dat.stat(N) as well.
+```
+If you don't want to use this folder structure, you should use a different implementation of
+`BaseStorageManager` interface. The `make_db_example` file also shows how to group together tiffs
+from different experiments (i.e. different subfolders within this folder structure).
 
 # V. Options
 
 ### Registration
 
-* _showTargetRegistration_ --- whether to show an image of the target frame immediately after it is computed. 
+* _showTargetRegistration_ --- whether to show an image of the target frame immediately after it is computed.
 * _PhaseCorrelation_ --- whether to use phase correlation (default is phase-correlation, if 0 then cross-correlation used).
 * _SubPixel_ --- accuracy level of subpixel registration (default is 10 = 0.1 pixel accuracy)
 * _kriging_ --- compute shifts using kernel regression with a gaussian kernel of width 1 onto a grid of 1/SubPixel (default is kriging = 1)
@@ -140,12 +162,12 @@ The output is a struct called dat which is saved into a mat file in ResultsSaveP
                       [t]: convolve in time with gauss. of std t, [t s]: convolve in time and space,
                       [t x y]: convolve in time, and in space with an ellipse rather than circle
 * _nimgbegend_ --- number of frames over which to average at beginning and end of experiment (if worried about drift) (default is 0 frames)
-                      
+
 **Block Registration (for high zoom/npixels)**
 
 * _nonrigid_ --- set to 1 for non-rigid registration (or set numBlocks > 1)
-* _numBlocks_ --- 1x2 array denoting the number of blocks to divide image in y and x (default is [8 1]) 
-* _blockFrac_ --- percent of image to use per block (default is 1/(numBlocks-1))          
+* _numBlocks_ --- 1x2 array denoting the number of blocks to divide image in y and x (default is [8 1])
+* _blockFrac_ --- percent of image to use per block (default is 1/(numBlocks-1))
 * _quadBlocks_ --- interpolate block shifts to single line shifts (6 blocks -> 512 lines) by fitting a quadratic function (default is 1)
 * _smoothBlocks_ --- if quadBlocks = 0, then smoothBlocks is the standard deviation of the gaussian smoothing kernel
 
@@ -170,8 +192,8 @@ currently only works with rigid registration, where each section of FOV is regis
 
 ### Cell detection
 
-* _sig_ --- spatial smoothing constant: smooths out the SVDs spatially. Indirectly forces ROIs to be more round. 
-* _nSVDforROI_ --- how many SVD components to keep for clustering. Usually ~ the number of expected cells. 
+* _sig_ --- spatial smoothing constant: smooths out the SVDs spatially. Indirectly forces ROIs to be more round.
+* _nSVDforROI_ --- how many SVD components to keep for clustering. Usually ~ the number of expected cells.
 * _ShowCellMap_ --- whether to show the clustering results as an image every 10 iterations of the clustering
 * _getROIs_ --- whether to run the ROI detection algorithm after registration
 * _stopSourcery_ --- stop clustering if # of ROIs extracted < (ROIs extracted on iteration 1) x (stopSourcery) (default is 1/10)
@@ -179,10 +201,10 @@ currently only works with rigid registration, where each section of FOV is regis
 
 ### SVD decomposition
 
-* _NavgFramesSVD_ --- for SVD, data has to be temporally binned. This number specifies the final number of points to be obtained after binning. In other words, datasets with many timepoints are binned in higher windows while small datasets are binned less. 
-* _getSVDcomps_ --- whether to obtain and save to disk SVD components of the registered movies. Useful for pixel-level analysis and for checking the quality of the registration (residual motion will show up as SVD components). This is a separate SVD decomposition from that done for cell clustering (does not remove a running baseline of each pixel). 
+* _NavgFramesSVD_ --- for SVD, data has to be temporally binned. This number specifies the final number of points to be obtained after binning. In other words, datasets with many timepoints are binned in higher windows while small datasets are binned less.
+* _getSVDcomps_ --- whether to obtain and save to disk SVD components of the registered movies. Useful for pixel-level analysis and for checking the quality of the registration (residual motion will show up as SVD components). This is a separate SVD decomposition from that done for cell clustering (does not remove a running baseline of each pixel).
 * _nSVDforROI_ --- how many SVD components to keep.
-* _getSVDcomps_ --- whether to obtain and save to disk SVD components of the registered movies. Useful for pixel-level analysis and for checking the quality of the registration (residual motion will show up as SVD components). This is a separate SVD decomposition from that done for cell clustering (does not remove a running baseline of each pixel). 
+* _getSVDcomps_ --- whether to obtain and save to disk SVD components of the registered movies. Useful for pixel-level analysis and for checking the quality of the registration (residual motion will show up as SVD components). This is a separate SVD decomposition from that done for cell clustering (does not remove a running baseline of each pixel).
 * _nSVD_ --- if _getSVDcomps_=1, then _nSVD_ specifies how many components to save
 
 
@@ -199,12 +221,12 @@ if using surround neuropil (_signalExtraction_ = 'surround')
 * _outerNeuropil_ --- radius of neuropil surround (set to Inf to use ops.ratioNeuropil)
 * _minNeuropilPixels_ --- minimum number of pixels in neuropil surround (radius will expand until this number is reached)
 
-### Spike deconvolution 
+### Spike deconvolution
 
-* _imageRate_ --- imaging rate per plane. 
+* _imageRate_ --- imaging rate per plane.
 * _sensorTau_ --- decay timescale (in seconds).
 * _maxNeurop_ --- neuropil contamination coef has to be less than this (sometimes good to impose a ceiling at 1, i.e. for interneurons)
-* _deconvType_ --- which type of deconvolution to use (either 'L0' or 'OASIS') 
+* _deconvType_ --- which type of deconvolution to use (either 'L0' or 'OASIS')
 
 ### Identifying red cells
 
@@ -215,20 +237,20 @@ Outputs are appended to stat in F.mat file
 * redcell = redratio > mean(redratio) + _redthres_ x std(redratio)
 * notred = redratio < mean(redratio) + _redmax_ x std(redratio)
 
-Options are 
+Options are
 * _redthres_  --- higher thres means fewer red cells (default 1.35)
 * _redmax_ --- the higher the max the more NON-red cells (default 1)
 
 ### Measures used by classifier
 
-The Suite2p classifier uses a number of features of each ROI to assign cell labels to ROIs. The classifier uses a naive Bayes approach for each feature, and models the distribution of each feature with a non-parametric, adaptively binned empirical distribution. The classifier is initialized with some standard distributions for these features, but is updated continuously with new data samples as the user refines the output manually in the GUI. 
+The Suite2p classifier uses a number of features of each ROI to assign cell labels to ROIs. The classifier uses a naive Bayes approach for each feature, and models the distribution of each feature with a non-parametric, adaptively binned empirical distribution. The classifier is initialized with some standard distributions for these features, but is updated continuously with new data samples as the user refines the output manually in the GUI.
 
-The features used are the following (can see values for each ROI by selecting it in the GUI). 
-* std = standard deviation of the cell trace, normalized to the size of the neuropil trace  
-* skew = skewness of the neuropil-subtracted cell trace  
-* pct = mean distance of pixels from ROI center, normalized to the same measuree for a perfect disk  
-* footprint = spatial extent of correlation between ROI trace and nearby pixels  
-* mimgProjAbs = whether this ROI shape is correlated to the shape on the mean image  
-* aspect_ratio = of an ellipse fit to the ROI  
+The features used are the following (can see values for each ROI by selecting it in the GUI).
+* std = standard deviation of the cell trace, normalized to the size of the neuropil trace
+* skew = skewness of the neuropil-subtracted cell trace
+* pct = mean distance of pixels from ROI center, normalized to the same measuree for a perfect disk
+* footprint = spatial extent of correlation between ROI trace and nearby pixels
+* mimgProjAbs = whether this ROI shape is correlated to the shape on the mean image
+* aspect_ratio = of an ellipse fit to the ROI
 
 

--- a/SpikeDetection/add_deconvolution.m
+++ b/SpikeDetection/add_deconvolution.m
@@ -2,56 +2,54 @@
 % by default it optimizes the neuropil coefficients
 % max neuropil coefficients set in ops.maxNeurop
 
-function add_deconvolution(ops, db, iplane0)
-ops = build_ops3(db, ops);
+function add_deconvolution(sm)
+ops = sm.options;
 ops0 = ops;
 
 % ops.deconvType = 'OASIS' (default) or 'L0'. See
-% http://www.biorxiv.org/content/early/2017/06/27/156786 for more info. 
+% http://www.biorxiv.org/content/early/2017/06/27/156786 for more info.
 
 % warning: ops0.imageRate now represents the TOTAL frame rate of the recording over all planes. This warning will be disabled in a future version.
 
-for i =  1:length(ops.planesToProcess)    
-    iplane  = ops0.planesToProcess(i);
-    
-    fpath = sprintf('%s/F_%s_%s_plane%d_proc.mat', ops.ResultsSavePath, ...
-        ops.mouse_name, ops.date, iplane);
+for i =  1:length(ops.planesToProcess)
+    iplane  = ops.planesToProcess(i);
+
+    fpath = sm.getFileForPlane('f_proc', iplane);
     if exist(fpath, 'file')
         load(fpath);
     else
-        fpath = sprintf('%s/F_%s_%s_plane%d.mat', ops.ResultsSavePath, ...
-            ops.mouse_name, ops.date, iplane);
+        fpath = sm.getFileForPlane('f', iplane);
         dat = load(fpath);
     end
-    
+
     if isfield(dat, 'dat')
         dat = dat.dat; % just in case...
     end
-    
+
     % if z-drift computed, apply correction
     for j = 1:length(dat.Fcell)
         Fcell{j}    = dat.Fcell{j};
         FcellNeu{j} = dat.FcellNeu{j};
     end
-    
+
     % overwrite fields of ops with those saved to file
     if getOr(ops, 'newops', 0)
         ops = addfields(dat.ops, ops0); % overwrite saved ops with new
     else
         ops = addfields(ops0, dat.ops);% overwrite new ops with saved
     end
-    
+
     % set up options for deconvolution
     ops.imageRate    = getOr(ops0, {'imageRate'}, 30); % total image rate (over all planes)
     ops.sensorTau    = getOr(ops0, {'sensorTau'}, 2); % approximate timescale in seconds
     ops.sameKernel   = getOr(ops0, {'sameKernel'}, 1); % 1 for same kernel per plane, 0 for individual kernels (not recommended)
     ops.sameKernel   = getOr(ops0, {'sameKernel'}, 1);
     ops.maxNeurop    = getOr(ops0, {'maxNeurop'}, Inf); % maximum neuropil coefficient (default no max)
-    ops.recomputeKernel    = getOr(ops0, {'recomputeKernel'}, 0);    
+    ops.recomputeKernel    = getOr(ops0, {'recomputeKernel'}, 0);
     ops.deconvNeuropil = getOr(ops0, {'deconvNeuropil'}, 0);   % whether to deconvolve the neuropil as well
-    
+
     fprintf('Spike deconvolution, plane %d... \n', iplane)
-    
+
     % construct Ff and Fneu
     Ff = [];
     Fneu = [];
@@ -59,7 +57,7 @@ for i =  1:length(ops.planesToProcess)
         Ff   = cat(1, Ff, Fcell{j}');
         Fneu = cat(1,Fneu, FcellNeu{j}');
     end
-    
+
     ops.fs                  = ops.imageRate/ops.nplanes;
     ops.estimateNeuropil    = getOr(ops0, 'estimateNeuropil', 1);
 
@@ -72,17 +70,17 @@ for i =  1:length(ops.planesToProcess)
             coefs = .8 * ones(size(Ff,2), 1);
         end
     end
-    
+
     if ops.deconvNeuropil
         ops.estimateNeuropil = 0;
         spNeu = wrapperDECONV(ops, Fneu);
     end
-    
+
     stat = dat.stat;
     for j = 1:size(Ff,2)
         stat(j).neuropilCoefficient = coefs(j);
     end
-    
+
     ops.SpkDcnvAlignToPlane = getOr(ops, 'SpkDcnvAlignToPlane', 0);
     if getOr(ops, 'runningBaseline', 0)
         Ff = Ff - bsxfun(@times, Fneu, [stat.neuropilCoefficient]);
@@ -92,29 +90,29 @@ for i =  1:length(ops.planesToProcess)
         end
         [sp, ~, ~,~, sd, ops, baselines] = wrapperDECONV(ops, Ff);
     end
-    
+
     for j = 1:size(Ff,2)
-        stat(j).noiseLevel          = sd(j);  
+        stat(j).noiseLevel          = sd(j);
         stat(j).baseline           = baselines(j);
     end
-    
+
     nCum = 0;
     for j = 1:length(dat.Fcell)
-       dat.sp{j} = sp(nCum + [1:size(dat.Fcell{j},2)], :)'; 
+       dat.sp{j} = sp(nCum + [1:size(dat.Fcell{j},2)], :)';
        if ops.deconvNeuropil
            dat.spNeu{j} = spNeu(nCum + [1:size(dat.Fcell{j},2)], :)';
        end
        nCum = nCum + size(dat.Fcell{j},2);
     end
-    
+
     % compute neuropil coefficient and run deconvolution on
     % neuropil-corrected trace
     %     stat = run_deconvolution3(ops, dat);
-    
+
     dat.stat = stat;
     dat.ops = ops;
     dat.Ff = Ff;
-        
+
     save(fpath, 'dat')    
 end
 %

--- a/build_ops3.m
+++ b/build_ops3.m
@@ -1,191 +1,190 @@
-function ops = build_ops3(db, ops)
-
-ops.nplanes = getOr(ops, 'nplanes', 1);
-ops.nchannels = getOr(ops, 'nchannels', 1);
-ops.readTiffHeader = getOr(ops,'readTiffHeader',1);
-if isfield(db, 'expred')
-    if ~isempty(db.expred)
-        ops.nchannels_red = getOr(ops, 'nchannels_red', 2);
-    end
-end
-
-% ops = db;
-if ~iscell(db.mouse_name)
-    % this is the usual case where we have a simple single session recording
-    ops = addfields(ops, db);
-    
-    for k = 1:length(db.expts)
-        ops.SubDirs{k}    = num2str(db.expts(k));
-    end
-    if isempty(db.expts)
-        ops.SubDirs{1} = [];
-    end
-    
-    if ~isfield(ops, 'RootDir')
-        ops.RootDir = fullfile(ops.RootStorage, ops.mouse_name, ops.date);
-    end
-    
-    % build file list
-    ops.fsroot = [];
-    for j = 1:length(ops.SubDirs)
-        ffile = dir(fullfile(ops.RootDir, ops.SubDirs{j}, '*.tif'));
-        fname = struct2cell(ffile);
-        fname = fname(1,:)';
-        [~,index] = sort_nat(fname);
-        ops.fsroot{j} = ffile(index);
-        ops.fsroot{j} = cat(1, ops.fsroot{j}, ...
-            dir(fullfile(ops.RootDir, ops.SubDirs{j}, '*.tiff')));
-        for k = 1:length(ops.fsroot{j})
-            ops.fsroot{j}(k).name = fullfile(ops.RootDir, ops.SubDirs{j}, ops.fsroot{j}(k).name);
+function options = build_ops3(db, options)
+    options.nplanes = getOr(options, 'nplanes', 1);
+    options.nchannels = getOr(options, 'nchannels', 1);
+    options.readTiffHeader = getOr(options,'readTiffHeader',1);
+    if isfield(db, 'expred')
+        if ~isempty(db.expred)
+            options.nchannels_red = getOr(options, 'nchannels_red', 2);
         end
     end
-    
-    if isfield(db, 'expred') && ~isempty(db.expred) && ...
-            (~isfield(db, 'nchannels_red') || isempty(db.nchannels_red))
-        ffile = dir(fullfile(ops.RootDir, num2str(db.expred), '*.tif'));
-        fname = struct2cell(ffile);
-        fname = fname(1,:)';
-        [~,index] = sort_nat(fname);
-        ops.fsred = ffile(index); 
-        for k = 1:length(ops.fsroot{j})
-            ops.fsred(k).name = fullfile(ops.RootDir, num2str(db.expred), ops.fsred(k).name);
+
+    % options = db;
+    if ~iscell(db.mouse_name)
+        % this is the usual case where we have a simple single session recording
+        options = addfields(options, db);
+
+        for k = 1:length(db.expts)
+            options.SubDirs{k}    = num2str(db.expts(k));
         end
-    end
-else
-    % here we might have multiple sessions, which we want to be analyzed
-    % together (exactly the same FOV)
-    nSessions = length(db.mouse_name);
-    % a backwards compatible version of db
-    dbCompat = db;
-    dbCompat.mouse_name = db.mouse_name{1};
-    dbCompat.date = db.date{1};
-    dbCompat.expts = cell2mat(db.expts(:)');
-    ops = addfields(ops, dbCompat);
-    ops.db_orig = db;
-    
-    ops.fsroot = cell(0);
-    ops.SubDirs = cell(0);
-    for iSession = 1:nSessions
-        ops.RootDir = fullfile(ops.RootStorage, db.mouse_name{iSession}, db.date{iSession});
-        for iExp = 1:length(db.expts{iSession})
-            ops.SubDirs{end+1} = num2str(db.expts{iSession}(iExp));
-            ops.fsroot{end+1} = dir(fullfile(ops.RootDir, ops.SubDirs{end}, '*.tif'));
-            for iFile = 1:length(ops.fsroot{end})
-                ops.fsroot{end}(iFile).name = fullfile(ops.RootDir, ops.SubDirs{end}, ops.fsroot{end}(iFile).name);
+        if isempty(db.expts)
+            options.SubDirs{1} = [];
+        end
+
+        if ~isfield(options, 'RootDir')
+            options.RootDir = fullfile(options.RootStorage, options.mouse_name, options.date);
+        end
+
+        % build file list
+        options.fsroot = [];
+        for j = 1:length(options.SubDirs)
+            ffile = dir(fullfile(options.RootDir, options.SubDirs{j}, '*.tif'));
+            fname = struct2cell(ffile);
+            fname = fname(1,:)';
+            [~,index] = sort_nat(fname);
+            options.fsroot{j} = ffile(index);
+            options.fsroot{j} = cat(1, options.fsroot{j}, ...
+                dir(fullfile(options.RootDir, options.SubDirs{j}, '*.tiff')));
+            for k = 1:length(options.fsroot{j})
+                options.fsroot{j}(k).name = fullfile(options.RootDir, options.SubDirs{j}, options.fsroot{j}(k).name);
             end
         end
-    end
-    % this line to be backward compatible (just in case)
-    ops.RootDir = fullfile(ops.RootStorage, ops.mouse_name, ops.date);
-end
 
-if ops.readTiffHeader
-    try
-        % MK code for automatically determining number of planes and channels
-        [~, header] = loadFramesBuff(ops.fsroot{1}(1).name, 1, 1, 1);
-        
-        hh=header{1};
-        
-        verStr = ['SI.VERSION_MAJOR = ',char(39),'2016b',char(39)];
-        
-        if contains(hh, verStr) % For scanimage 2016b, SF
-            str = hh(strfind(hh,'channelSave = '):end);
-            ind = strfind(str, 'SI');
-            ch = str2num(str(15 : ind(1)-1));
-            ops.nchannels = length(ch);
-            
-            fastZEnable = sscanf(hh(strfind(hh,'hFastZ.enable = '):end), 'hFastZ.enable = %s');
-            fastZEnable = strcmp(fastZEnable,'true');
-            fastZDiscardFlybackFrames = sscanf(hh(strfind(hh, 'hFastZ.discardFlybackFrames = '):end), 'hFastZ.discardFlybackFrames = %s');
-            fastZDiscardFlybackFrames = strcmp(fastZDiscardFlybackFrames,'true');
-            stackNumSlices = sscanf(hh(strfind(hh, 'hStackManager.numSlices = '):end), 'hStackManager.numSlices = %d');
-            
-            ops.nplanes = 1;
-            
-            if fastZEnable
-                ops.nplanes = stackNumSlices+fastZDiscardFlybackFrames;
-            end
-            
-            str = hh(strfind(hh, 'scanZoomFactor = '):end);
-            ind = strfind(str, 'SI');
-            ops.zoomMicro = str2double(str(18 : ind(1)-1));
-            
-            ops.imageRate = sscanf(hh(strfind(hh, 'scanFrameRate = '):end), 'scanFrameRate = %f');
-            
-            if isfield(db, 'expred') && ~isempty(db.expred) && ...
-                    (~isfield(db, 'nchannels_red') || isempty(db.nchannels_red))
-                [~, header] = loadFramesBuff(ops.fsred(1).name, 1, 1, 1);
-                hh=header{1};
-                str = hh(strfind(hh, 'channelSave = '):end);
-                ind = strfind(str, 'SI');
-                ch = str2num(str(15 : ind(1)-1));
-                ops.nchannels_red = length(ch);
-            end
-            
-        end
-        
-        % Old scanimage
-        
-        str = hh(strfind(hh, 'channelsSave = '):end);
-        ind = strfind(str, 'scanimage');
-        ch = str2num(str(16 : ind(1)-1));
-        ops.nchannels = length(ch);
-        
-        fastZEnable = sscanf(hh(strfind(hh, 'fastZEnable = '):end), 'fastZEnable = %d');
-        fastZDiscardFlybackFrames = sscanf(hh(strfind(hh, 'fastZDiscardFlybackFrames = '):end), 'fastZDiscardFlybackFrames = %d');
-        if isempty(fastZDiscardFlybackFrames)
-            fastZDiscardFlybackFrames = 0;
-        end
-        stackNumSlices = sscanf(hh(strfind(hh, 'stackNumSlices = '):end), 'stackNumSlices = %d');
-        
-        ops.nplanes = 1;
-        if fastZEnable
-            ops.nplanes = stackNumSlices+fastZDiscardFlybackFrames;
-        end
-        
-        str = hh(strfind(hh, 'scanZoomFactor = '):end);
-        ind = strfind(str, 'scanimage');
-        ops.zoomMicro = str2double(str(18 : ind(1)-1));
-        
-        ops.imageRate = sscanf(hh(strfind(hh, 'scanFrameRate = '):end), 'scanFrameRate = %f');
-        
-        % get number of channels of red experiment
         if isfield(db, 'expred') && ~isempty(db.expred) && ...
                 (~isfield(db, 'nchannels_red') || isempty(db.nchannels_red))
-            [~, header] = loadFramesBuff(ops.fsred(1).name, 1, 1, 1);
+            ffile = dir(fullfile(options.RootDir, num2str(db.expred), '*.tif'));
+            fname = struct2cell(ffile);
+            fname = fname(1,:)';
+            [~,index] = sort_nat(fname);
+            options.fsred = ffile(index);
+            for k = 1:length(options.fsroot{j})
+                options.fsred(k).name = fullfile(options.RootDir, num2str(db.expred), options.fsred(k).name);
+            end
+        end
+    else
+        % here we might have multiple sessions, which we want to be analyzed
+        % together (exactly the same FOV)
+        nSessions = length(db.mouse_name);
+        % a backwards compatible version of db
+        dbCompat = db;
+        dbCompat.mouse_name = db.mouse_name{1};
+        dbCompat.date = db.date{1};
+        dbCompat.expts = cell2mat(db.expts(:)');
+        options = addfields(options, dbCompat);
+        options.db_orig = db;
+
+        options.fsroot = cell(0);
+        options.SubDirs = cell(0);
+        for iSession = 1:nSessions
+            options.RootDir = fullfile(options.RootStorage, db.mouse_name{iSession}, db.date{iSession});
+            for iExp = 1:length(db.expts{iSession})
+                options.SubDirs{end+1} = num2str(db.expts{iSession}(iExp));
+                options.fsroot{end+1} = dir(fullfile(options.RootDir, options.SubDirs{end}, '*.tif'));
+                for iFile = 1:length(options.fsroot{end})
+                    options.fsroot{end}(iFile).name = fullfile(options.RootDir, options.SubDirs{end}, options.fsroot{end}(iFile).name);
+                end
+            end
+        end
+        % this line to be backward compatible (just in case)
+        options.RootDir = fullfile(options.RootStorage, options.mouse_name, options.date);
+    end
+
+    if options.readTiffHeader
+        try
+            % MK code for automatically determining number of planes and channels
+            [~, header] = loadFramesBuff(options.fsroot{1}(1).name, 1, 1, 1);
+
             hh=header{1};
+
+            verStr = ['SI.VERSION_MAJOR = ',char(39),'2016b',char(39)];
+
+            if contains(hh, verStr) % For scanimage 2016b, SF
+                str = hh(strfind(hh,'channelSave = '):end);
+                ind = strfind(str, 'SI');
+                ch = str2num(str(15 : ind(1)-1));
+                options.nchannels = length(ch);
+
+                fastZEnable = sscanf(hh(strfind(hh,'hFastZ.enable = '):end), 'hFastZ.enable = %s');
+                fastZEnable = strcmp(fastZEnable,'true');
+                fastZDiscardFlybackFrames = sscanf(hh(strfind(hh, 'hFastZ.discardFlybackFrames = '):end), 'hFastZ.discardFlybackFrames = %s');
+                fastZDiscardFlybackFrames = strcmp(fastZDiscardFlybackFrames,'true');
+                stackNumSlices = sscanf(hh(strfind(hh, 'hStackManager.numSlices = '):end), 'hStackManager.numSlices = %d');
+
+                options.nplanes = 1;
+
+                if fastZEnable
+                    options.nplanes = stackNumSlices+fastZDiscardFlybackFrames;
+                end
+
+                str = hh(strfind(hh, 'scanZoomFactor = '):end);
+                ind = strfind(str, 'SI');
+                options.zoomMicro = str2double(str(18 : ind(1)-1));
+
+                options.imageRate = sscanf(hh(strfind(hh, 'scanFrameRate = '):end), 'scanFrameRate = %f');
+
+                if isfield(db, 'expred') && ~isempty(db.expred) && ...
+                        (~isfield(db, 'nchannels_red') || isempty(db.nchannels_red))
+                    [~, header] = loadFramesBuff(options.fsred(1).name, 1, 1, 1);
+                    hh=header{1};
+                    str = hh(strfind(hh, 'channelSave = '):end);
+                    ind = strfind(str, 'SI');
+                    ch = str2num(str(15 : ind(1)-1));
+                    options.nchannels_red = length(ch);
+                end
+
+            end
+
+            % Old scanimage
+
             str = hh(strfind(hh, 'channelsSave = '):end);
             ind = strfind(str, 'scanimage');
             ch = str2num(str(16 : ind(1)-1));
-            ops.nchannels_red = length(ch);
+            options.nchannels = length(ch);
+
+            fastZEnable = sscanf(hh(strfind(hh, 'fastZEnable = '):end), 'fastZEnable = %d');
+            fastZDiscardFlybackFrames = sscanf(hh(strfind(hh, 'fastZDiscardFlybackFrames = '):end), 'fastZDiscardFlybackFrames = %d');
+            if isempty(fastZDiscardFlybackFrames)
+                fastZDiscardFlybackFrames = 0;
+            end
+            stackNumSlices = sscanf(hh(strfind(hh, 'stackNumSlices = '):end), 'stackNumSlices = %d');
+
+            options.nplanes = 1;
+            if fastZEnable
+                options.nplanes = stackNumSlices+fastZDiscardFlybackFrames;
+            end
+
+            str = hh(strfind(hh, 'scanZoomFactor = '):end);
+            ind = strfind(str, 'scanimage');
+            options.zoomMicro = str2double(str(18 : ind(1)-1));
+
+            options.imageRate = sscanf(hh(strfind(hh, 'scanFrameRate = '):end), 'scanFrameRate = %f');
+
+            % get number of channels of red experiment
+            if isfield(db, 'expred') && ~isempty(db.expred) && ...
+                    (~isfield(db, 'nchannels_red') || isempty(db.nchannels_red))
+                [~, header] = loadFramesBuff(options.fsred(1).name, 1, 1, 1);
+                hh=header{1};
+                str = hh(strfind(hh, 'channelsSave = '):end);
+                ind = strfind(str, 'scanimage');
+                ch = str2num(str(16 : ind(1)-1));
+                options.nchannels_red = length(ch);
+            end
+        catch
         end
-    catch
     end
-end
-if isfield(ops, 'zoomMicro')
-    ops.zoom = getOr(ops, 'zoom', ops.zoomMicro);
-else
-    ops.zoom = getOr(ops, 'zoom', 1);
-end
+    if isfield(options, 'zoomMicro')
+        options.zoom = getOr(options, 'zoom', options.zoomMicro);
+    else
+        options.zoom = getOr(options, 'zoom', 1);
+    end
 
 
-if ~(isfield(ops, 'planesToProcess') && ~isempty(ops.planesToProcess))
-    ops.planesToProcess = 1:ops.nplanes;
-else
-    % planesToProcess is not working right now
-    ops.planesToProcess = 1:ops.nplanes;
-end
+    if ~(isfield(options, 'planesToProcess') && ~isempty(options.planesToProcess))
+        options.planesToProcess = 1:options.nplanes;
+    else
+        % planesToProcess is not working right now
+        options.planesToProcess = 1:options.nplanes;
+    end
 
-CharSubDirs = '';
-for i = 1:length(ops.SubDirs)
-    CharSubDirs = [CharSubDirs ops.SubDirs{i} '_'];
-end
-CharSubDirs = CharSubDirs(1:end-1);
-ops.CharSubDirs = CharSubDirs;
+    CharSubDirs = '';
+    for i = 1:length(options.SubDirs)
+        CharSubDirs = [CharSubDirs options.SubDirs{i} '_'];
+    end
+    CharSubDirs = CharSubDirs(1:end-1);
+    options.CharSubDirs = CharSubDirs;
 
-ops.ResultsSavePath = sprintf('%s//%s//%s//%s//', ops.ResultsSavePath, ops.mouse_name, ops.date, ...
-    CharSubDirs);
-    
-if isempty(db.expts)
-   ops.expts = [];
-end
+    options.ResultsSavePath = sprintf('%s//%s//%s//%s//', options.ResultsSavePath, options.mouse_name, options.date, ...
+        CharSubDirs);
+
+    if isempty(db.expts)
+       options.expts = [];
+    end

--- a/configFiles/make_db_example.m
+++ b/configFiles/make_db_example.m
@@ -1,6 +1,6 @@
 % UPDATE Christmas 2016: number of clusters determined automatically, but
 % do specify the "diameter" of an average cell for best results. You can do this with either
-% db(iexp).diameter, or ops0.diameter. 
+% db(iexp).diameter, or ops0.diameter.
 
 i = 0;
 
@@ -9,6 +9,7 @@ db(i).mouse_name    = 'M150329_MP009';
 db(i).date          = '2015-04-29';
 db(i).expts         = [4 5 6];
 db(i).diameter      = 12;
+db(i).rootStorage   = 'F:\workspace\dataFolder'; % See CortexLabStorageManager for details
 %
 i = i+1;
 db(i).mouse_name    = 'M150329_MP009';
@@ -32,6 +33,7 @@ db(i).expts         = {[2010 2107], [1 2 3]};
 db(i).diameter      = 12;
 
 % example for datasets without folder structure
+i = i + 1;
 db(i).mouse_name    = 'notImportant';
 db(i).date          = '2016';
 db(i).expts         = []; % leave empty, or specify subolders as numbers
@@ -43,5 +45,10 @@ db(i).RootDir       = 'F:\DATA\neurofinder\neurofinder.01.00\images'; % specify 
 % db(i).BiDiPhase        = 0; % adjust the relative phase of consecutive lines
 % db(i).nSVD             = 1000; % will overwrite the default, only for this dataset
 % db(i).comments      = 'this was an adaptation experiment';
-% db(i).expred        = [4]; % say one block which had a red channel 
+% db(i).expred        = [4]; % say one block which had a red channel
 % db(i).nchannels_red = 2; % how many channels did the red block have in total (assumes red is last)
+
+% Convert db structure to storage manager format
+newDb = CortexLabStorageManager.convertDbToStorageManager(db);
+clear db;
+db = newDb;

--- a/master_file_example.m
+++ b/master_file_example.m
@@ -6,12 +6,12 @@
 % (ly x lx x time like green channel)
 
 % UPDATE end-of-summer 2017: default neuropil extraction is now "surround"
-% and it's very fast. Cell extraction is on the raw data (no pixel-scaling or smoothing). 
+% and it's very fast. Cell extraction is on the raw data (no pixel-scaling or smoothing).
 
 % UPDATE summer 2017: default spike deconvolution changed to a customized version of
 % OASIS (due to our results in this paper http://www.biorxiv.org/content/early/2017/06/27/156786). Please
 % Please download the OASIS code from https://github.com/zhoupc/OASIS_matlab, and
-% add the folder, with its subfolders, to your Matlab path. 
+% add the folder, with its subfolders, to your Matlab path.
 
 % UPDATE Christmas 2016: number of clusters determined automatically, but
 % do specify the "diameter" of an average cell for best results. You can do this with either
@@ -21,29 +21,25 @@
 % **** and for more options available ****
 addpath('D:\CODE\MariusBox\runSuite2P') % add the path to your make_db file
 
-% overwrite any of these default options in your make_db file for individual experiments
-make_db_example; % RUN YOUR OWN MAKE_DB SCRIPT TO RUN HERE
-
 ops0.toolbox_path = 'C:\CODE\GitHub\Suite2P';
 if exist(ops0.toolbox_path, 'dir')
-	addpath(genpath(ops0.toolbox_path)) % add local path to the toolbox
+    addpath(genpath(ops0.toolbox_path)) % add local path to the toolbox
 else
-	error('toolbox_path does not exist, please change toolbox_path');
+    error('toolbox_path does not exist, please change toolbox_path');
 end
 
 % mex -largeArrayDims SpikeDetection/deconvL0.c (or .cpp) % MAKE SURE YOU COMPILE THIS FIRST FOR DECONVOLUTION
 
-ops0.useGPU                 = 0; % if you can use an Nvidia GPU in matlab this accelerates registration approx 3 times. You only need the Nvidia drivers installed (not CUDA).
+% overwrite any of these default options in your make_db file for individual experiments
+make_db_example; % RUN YOUR OWN MAKE_DB SCRIPT TO RUN HERE
+
+ops0.useGPU                 = gpuDeviceCount > 0; % if you can use an Nvidia GPU in matlab this accelerates registration approx 3 times. You only need the Nvidia drivers installed (not CUDA).
 ops0.fig                    = 1; % turn off figure generation with 0
 % ops0.diameter               = 12; % most important parameter. Set here, or individually per experiment in make_db file
 
 % ---- root paths for files and temporary storage (ideally an SSD drive. my SSD is C:/)
-ops0.RootStorage            = '//zserver4/Data/2P'; % Suite2P assumes a folder structure, check out README file
-ops0.temp_tiff              = 'C:/DATA/temp.tif'; % copies each remote tiff locally first, into this file
-ops0.RegFileRoot            = 'C:/DATA/';  % location for binary file
+% are defined through the db.
 ops0.DeleteBin              = 1; % set to 1 for batch processing on a limited hard drive
-ops0.ResultsSavePath        = 'D:/DATA/F'; % a folder structure is created inside
-ops0.RegFileTiffLocation    = []; %'D:/DATA/'; % leave empty to NOT save registered tiffs (slow)
 % if you want to save red channel tiffs, also set ops0.REDbinary = 1
 
 % ---- registration options ------------------------------------- %
@@ -51,7 +47,7 @@ ops0.doRegistration         = 1; % skip (0) if data is already registered
 ops0.showTargetRegistration = 1; % shows the image targets for all planes to be registered
 ops0.PhaseCorrelation       = 1; % set to 0 for non-whitened cross-correlation
 ops0.SubPixel               = Inf; % 2 is alignment by 0.5 pixel, Inf is the exact number from phase correlation
-ops0.NimgFirstRegistration  = 500; % number of images to include in the first registration pass 
+ops0.NimgFirstRegistration  = 500; % number of images to include in the first registration pass
 ops0.nimgbegend             = 0; % frames to average at beginning and end of blocks
 ops0.dobidi                 = 1; % infer and apply bidirectional phase offset
 
@@ -60,8 +56,8 @@ ops0.ShowCellMap            = 1; % during optimization, show a figure of the clu
 ops0.sig                    = 0.5;  % spatial smoothing length in pixels; encourages localized clusters
 ops0.nSVDforROI             = 1000; % how many SVD components for cell clustering
 ops0.NavgFramesSVD          = 5000; % how many (binned) timepoints to do the SVD based on
-ops0.signalExtraction       = 'surround'; % how to extract ROI and neuropil signals: 
-%  'raw' (no cell overlaps), 'regression' (allows cell overlaps), 
+ops0.signalExtraction       = 'surround'; % how to extract ROI and neuropil signals:
+%  'raw' (no cell overlaps), 'regression' (allows cell overlaps),
 %  'surround' (no cell overlaps, surround neuropil model)
 
 % ----- neuropil options (if 'surround' option) ------------------- %
@@ -85,7 +81,7 @@ ops0.AlignToRedChannel      = 0; % compute registration offsets using red channe
 ops0.REDbinary              = 0; % make a binary file of registered red frames
 % if db.expred, then compute mean red image for green experiments with red
 % channel available while doing registration
-ops0.redMeanImg             = 0; 
+ops0.redMeanImg             = 0;
 % for red cell detection (identify_redcells_sourcery.m)
 % redratio = red pixels inside / red pixels outside
 % redcell = redratio > mean(redratio) + redthres*std(redratio)
@@ -94,37 +90,43 @@ ops0.redthres               = 1.5; % the higher the thres the less red cells
 ops0.redmax                 = 1; % the higher the max the more NON-red cells
 
 db0 = db;
+
+sm = CortexLabStorageManager(ops0);
+for i = 1:length(db)
+    sm.addEntry(db(i));
+end
+
 %% RUN THE PIPELINE HERE
 
-for iexp = 1 %[1:length(db0)]
-    db = db0(iexp);
-    run_pipeline(db, ops0);
-    
+for i = 1 %[1:sm.getNumEntries()]
+    sm.selectEntry(i);
+    run_pipeline(sm);
+
     % deconvolved data into st, and neuropil subtraction coef in stat
-    add_deconvolution(ops0, db);
-    
+    add_deconvolution(sm);
+
     % add red channel information (if it exists)
-    if isfield(db,'expred') && ~isempty(db.expred)
-        % creates mean red channel image aligned to green channel
-        % use this if you didn't get red channel during registration
-        % OR you have a separate experiment with red and green just for this
-        red_expts = ismember(db.expts, getOr(db, 'expred', []));
-        if ~ops0.redMeanImg || sum(red_expts)==0
-            run_REDaddon_sourcery(db, ops0);
-        end
-        
-        % identify red cells in mean red channel image
-        % fills dat.stat.redcell, dat.stat.notred, dat.stat.redprob
-        identify_redcells_sourcery(db, ops0); 
-        
+    expred = sm.getOr('expred', []);
+    if ~isempty(expred)
+        % % creates mean red channel image aligned to green channel
+        % % use this if you didn't get red channel during registration
+        % % OR you have a separate experiment with red and green just for this
+        % red_expts = ismember(db.expts, getOr(db, 'expred', []));
+        % if ~ops0.redMeanImg || sum(red_expts)==0
+        %     run_REDaddon_sourcery(db, ops0);
+        % end
+
+        % % identify red cells in mean red channel image
+        % % fills dat.stat.redcell, dat.stat.notred, dat.stat.redprob
+        % identify_redcells_sourcery(db, ops0);
     end
-    
+
 end
 %% STRUCTURE OF RESULTS FILE
 % cell traces are in dat.Fcell
 % neuropil traces are in dat.FcellNeu
 % manual, GUI overwritten "iscell" labels are in dat.cl.iscell
-%  
+%
 % stat(icell) contains all other information:
 % iscell: automated label, based on anatomy
 % neuropilCoefficient: neuropil subtraction coefficient, based on maximizing the skewness of the corrected trace (ICA)

--- a/preRegistration/GetRandFrames.m
+++ b/preRegistration/GetRandFrames.m
@@ -1,6 +1,6 @@
 % gets random frames (in total NimgFirstRegistration)
 % frames are used for initializing registration
-function IMG = GetRandFrames(fs, ops)
+function IMG = GetRandFrames(sm, ops)
 
 nplanes            = getOr(ops, {'nplanes'}, 1);
 nchannels          = getOr(ops, {'nchannels'}, 1);
@@ -9,17 +9,21 @@ rchannel           = getOr(ops, {'rchannel'}, 2);
 red_align          = getOr(ops, {'AlignToRedChannel'}, 0);
 
 % if not empty, generate target image from specified experiment (useful if there is slow drift in data)
-targetImage        = getOr(ops, {'targetImage'}, []); 
+targetImage        = getOr(ops, {'targetImage'}, []);
 
-ntifs = sum(cellfun(@(x) numel(x), fs)); % total number of tiff files
-nfmax = max(1, round(ops.NimgFirstRegistration/ntifs)); % number of tiffs to take per file
-if nfmax>=2000
+sm.resetCurrentEntry();
+
+%ntifs = sum(cellfun(@(x) numel(x), fs)); % total number of tiff files
+ntifs = sm.getNumFiles(); % total number of tiff files
+nfmax = max(1, round(ops.NimgFirstRegistration / ntifs)); % number of tiffs to take per file
+if nfmax >= 2000
     nfmax = 1999;
 end
 
 % size of images
-nbytes = fs{1}(1).bytes;
-Info0 = imfinfo(fs{1}(1).name);
+firstFile = sm.getFirstFile();
+Info0 = imfinfo(firstFile);
+nbytes = Info0(1).FileSize;
 nFr = length(Info0);
 Ly = Info0(1).Height;
 Lx = Info0(1).Width;
@@ -32,24 +36,32 @@ IMG = zeros(Ly, Lx, nplanes, ops.NimgFirstRegistration, 'single');
 % grab random frames from target experiment
 if ~isempty(targetImage)
     k = targetImage(1);
+    sm.seekToPartition(k);
+    [fileName, fileInfo] = sm.getFile();
+
     % compute number of frames in tiff
-    if abs(nbytes - fs{k}(1).bytes)>1e3
-        nbytes = fs{k}(1).bytes;
-        nFr = nFrames(fs{k}(1).name);
+    if abs(nbytes - fileInfo.bytes) > 1e3
+        nbytes = fileInfo.bytes;
+        nFr = nFrames(fileName);
     end
-    startTiff = floor(length(fs{k})/2 - ...
+    numFiles = sm.getNumFiles(k);
+
+    startTiff = floor(numFiles/2 - ...
         nplanes*nchannels*ops.NimgFirstRegistration/2/nFr);
     iplane = mod(((startTiff-1)*nFr)/nchannels-1, nplanes) + 1;
     j = startTiff;
+    for i = 1:startTiff-1
+        [fileName, fileInfo] = sm.getFile();
+    end
     while indx < ops.NimgFirstRegistration
         offset = 0;
         if j == 1
             offset = nchannels*nplanes;
         end
         % compute number of frames in tiff if size different from previous
-        if abs(nbytes - fs{k}(j).bytes)>1e3
-            nbytes = fs{k}(j).bytes;
-            nFr = nFrames(fs{k}(j).name);
+        if abs(nbytes - fileInfo.bytes)>1e3
+            nbytes = fileInfo.bytes;
+            nFr = nFrames(fileName);
         end
         numFr = min(ops.NimgFirstRegistration-indx, nFr/nchannels/nplanes);
         % load red channel if red_align == 1
@@ -60,65 +72,58 @@ if ~isempty(targetImage)
             ichanset = [offset + nchannels*(nplanes-iplane) + [ichannel;...
                 nchannels*nplanes*numFr]; nchannels];
         end
+
         iplane = mod(iplane + nFr/nchannels - 1, nplanes) + 1;
-        data = loadFramesBuff(fs{k}(j).name, ichanset(1), ichanset(2), ichanset(3));
+        data = loadFramesBuff(fileName, ichanset(1), ichanset(2), ichanset(3));
         data = reshape(data, Ly, Lx, nplanes, []);
-        
-        IMG(:,:,:,indx+(1:size(data,4))) = data;
-        indx = indx + size(data,4);
+
+        IMG(:, :, :, indx+(1:size(data, 4))) = data;
+        indx = indx + size(data, 4);
         j = j + 1;
+        [fileName, fileInfo] = sm.getFile();
     end
 % grab frames from all files
 else
-    for k = 1:length(ops.SubDirs)
-        iplane0 = 1;
-        nchannels = ops.nchannels;
-        if ~isempty(ops.expts)
-            if ismember(ops.expts(k), getOr(ops, 'expred', []))
-                nchannels = ops.nchannels_red;
-            end
+    lastPartition = -1;
+    while sm.hasData()
+        [fileName, fileInfo] = sm.getFile();
+        if abs(nbytes - fileInfo.bytes) > 1e3
+            nbytes = fileInfo.bytes;
+            nFr = nFrames(fileName);
         end
-        
-        for j = 1:length(fs{k})
-            % compute number of frames in tiff if size different from previous
-            if abs(nbytes - fs{k}(j).bytes)>1e3
-                nbytes = fs{k}(j).bytes;
-                nFr = nFrames(fs{k}(j).name);
-            end
-            if j==1
-                offset = nchannels*nplanes;
-            else
-                offset = 0;
-            end
-            % check if there are enough frames in the tiff
-            if nFr<(nchannels*nplanes*nfmax+offset)
-                continue;
-            end
-            
-            iplane0 = mod(iplane0-1, nplanes) + 1;
-            % load red channel if red_align == 1
-            if red_align
-                ichanset = [offset + nchannels*(iplane0-1) + [rchannel;...
-                    nchannels*nplanes*nfmax]; nchannels];
-            else
-                ichanset = [offset + nchannels*(iplane0-1) + [ichannel;...
-                    nchannels*nplanes*nfmax]; nchannels];
-            end
-            iplane0 = iplane0 - nFr/nchannels;
-            data = loadFramesBuff(fs{k}(j).name, ichanset(1),ichanset(2), ichanset(3));
-            data = reshape(data, Ly, Lx, nplanes, []);
-            
-            IMG(:,:,:,indx+(1:size(data,4))) = data;
-            indx = indx + size(data,4);
-            
-            if indx>ops.NimgFirstRegistration
-                break;
-            end
+        if lastPartition ~= fileInfo.partition
+            offset = nchannels * nplanes;
+            lastPartition = fileInfo.partition;
+            iplane0 = 0;
+        else
+            offset = 0;
         end
-        
-        if indx>ops.NimgFirstRegistration
+
+        % check if there are enough frames in the tiff
+        if nFr < (nchannels*nplanes*nfmax+offset)
+            continue;
+        end
+
+        iplane0 = mod(iplane0-1, nplanes) + 1;
+        % load red channel if red_align == 1
+        if red_align
+            ichanset = [offset + nchannels*(iplane0-1) + [rchannel;...
+                nchannels*nplanes*nfmax]; nchannels];
+        else
+            ichanset = [offset + nchannels*(iplane0-1) + [ichannel;...
+                nchannels*nplanes*nfmax]; nchannels];
+        end
+
+        iplane0 = iplane0 - nFr/nchannels;
+        data = loadFramesBuff(fileName, ichanset(1), ichanset(2), ichanset(3));
+        data = reshape(data, Ly, Lx, nplanes, []);
+
+        IMG(:, :, :, indx+(1:size(data, 4))) = data;
+        indx = indx + size(data, 4);
+
+        if indx > ops.NimgFirstRegistration
             break;
         end
     end
 end
-IMG(:,:,:,(1+indx):end) = [];
+IMG(:, :, :, (1+indx):end) = [];

--- a/readWrite/write_reg_to_tiff.m
+++ b/readWrite/write_reg_to_tiff.m
@@ -1,51 +1,30 @@
-function ops = write_reg_to_tiff(fid, ops, iplane, isRED)
+function write_reg_to_tiff(fid, ops, iplane, isRED, sm)
 
 Ly = ops.Ly;
 Lx = ops.Lx;
 bitspersamp = 16;
 
 frewind(fid);
-for k = 1:length(ops.SubDirs)
-    ix = 0;    
-    nframesleft = ops.Nframes(k);
+numPartitions = sm.getNumPartitions();
+for k = 1:numPartitions
+    sm.seekToPartition(k);
     
-    datend = [];
-    while nframesleft>0
-         ix = ix + 1;
-        nfrtoread = min(nframesleft, 2000);
-        data = fread(fid,  Ly*Lx*nfrtoread, 'int16');                
-        nframesleft = nframesleft - nfrtoread;
-        data = reshape(data, Ly, Lx, []);        
+    ix = 0;
+    nframesleft = ops.Nframes(k);
 
-         % this is now done in a separate function
-%         if ix==1
-%             navg = min(size(data,3), ops.nimgbegend);
-%             ops.mimg_beg(:,:,k) = mean(data(:,:,1:navg), 3);
-%         end
-%         if nframesleft<ops.nimgbegend
-%             nconc = min(ops.nimgbegend - nframesleft, nfrtoread);
-%             datend = cat(3, datend, data(:,:,(nfrtoread-nconc+1):nfrtoread));
-%         end
-%         if nframesleft<=0
-%              ops.mimg_end(:,:,k) = mean(datend, 3);
-%         end
-        
-        foldr = fullfile(ops.RegFileTiffLocation, ops.mouse_name, ops.date, ...
-            ops.SubDirs{k}, sprintf('Plane%d', iplane));
-        if ~exist(foldr, 'dir')
-            mkdir(foldr)
-        end
+    while nframesleft > 0
+        ix = ix + 1;
+        nfrtoread = min(nframesleft, 2000);
+        data = fread(fid,  Ly*Lx*nfrtoread, 'int16');
+        nframesleft = nframesleft - nfrtoread;
+        data = reshape(data, Ly, Lx, []);
+
         if isRED
-            partname = sprintf('%s_%s_%s_2P_plane%d_%d_RED.tif', ops.date, ops.SubDirs{k}, ...
-                ops.mouse_name, iplane, ix);
-        
+            fname = sm.registrationTiffPath(iplane, ix, 'red');
         else
-            partname = sprintf('%s_%s_%s_2P_plane%d_%d.tif', ops.date, ops.SubDirs{k}, ...
-            ops.mouse_name, iplane, ix);
-                    
+            fname = sm.registrationTiffPath(iplane, ix);
         end
-        fname = fullfile(foldr, partname);
-        
-        TiffWriter(int16(data),fname,bitspersamp);
+
+        TiffWriter(int16(data), fname, bitspersamp);
     end
 end

--- a/registration/openBinFiles.m
+++ b/registration/openBinFiles.m
@@ -1,47 +1,33 @@
 % open binary files to write registered tiffs to
 % takes ops, ops1, and red_binary (if 1 then write red channel to binary)
-function [ops1, fid, fidRED, fidIntpol] = openBinFiles(ops, ops1, red_binary)
-numPlanes = numel(ops.planesToProcess);
-fid    = cell(numPlanes, size(ops1,2));
-fidRED = cell(numPlanes, size(ops1,2));
+function [ops1, fid, fidRED, fidIntpol] = openBinFiles(sm, ops1, red_binary)
+numPlanes = numel(sm.options.planesToProcess);
+fid    = cell(numPlanes, size(ops1, 2));
+fidRED = cell(numPlanes, size(ops1, 2));
 fidIntpol = [];
-if ops.interpolateAcrossPlanes == 1 && ~isempty(ops.RegFileBinLocation)
+regFileBinLocation = sm.getOr('RegFileBinLocation');
+doInterpolation = sm.getOr('interpolateAcrossPlanes') && ~isempty(regFileBinLocation);
+if doInterpolation
     fidIntpol = cell(numPlanes, size(ops1,2));
 end
 
 for i = 1:numPlanes
-    for j = 1:size(ops1,2)
-        ops1{i,j}.RegFile = fullfile(ops.RegFileRoot, ...
-            sprintf('%s_%s_%s_plane%d.bin', ops.mouse_name, ops.date, ...
-            ops.CharSubDirs, i + (j-1)*numPlanes));
-        regdir = fileparts(ops1{i,j}.RegFile);
-        if ~exist(regdir, 'dir')
-            mkdir(regdir);
-        end
-        
+    for j = 1:size(ops1, 2)
+        planeInd = i + (j-1)*numPlanes;
+        ops1{i, j}.RegFile = sm.registrationFileOnFastStorage(planeInd);
+
         % open bin file for writing
-        fid{i,j}              = fopen(ops1{i,j}.RegFile, 'w');
-        
+        fid{i, j} = fopen(ops1{i, j}.RegFile, 'w');
+
         if red_binary
-            ops1{i,j}.RegFile2 = fullfile(ops.RegFileRoot, ...
-                sprintf('%s_%s_%s_plane%d_RED.bin', ops.mouse_name, ops.date, ...
-                ops.CharSubDirs, i + (j-1)*numPlanes));
-            fidRED{i,j}              = fopen(ops1{i,j}.RegFile2, 'w');
+            ops1{i, j}.RegFile2 = sm.registrationFileOnFastStorage(planeInd, 'red');
+            fidRED{i, j} = fopen(ops1{i, j}.RegFile2, 'w');
         end
-        
-        if ops.interpolateAcrossPlanes && ~isempty(ops.RegFileBinLocation)
+
+        if doInterpolation
             % open separate files for result after averaging across
             % neighbouring planes
-            str = sprintf('%d_',ops1{i,j}.expts);
-            str(end) = [];
-            folder = fullfile(ops1{i,j}.RegFileBinLocation, ops1{i,j}.mouse_name, ...
-                ops1{i,j}.date, str, 'interpolated');
-            if ~exist(folder, 'dir')
-                mkdir(folder);
-            end
-            fidIntpol{i,j} = fopen(fullfile(folder, ...
-                sprintf('%s_%s_%s_plane%d.bin', ops.mouse_name, ops.date, ...
-                ops.CharSubDirs, i + (j-1)*numPlanes)), 'w');
+            fidIntpol{i, j} = fopen(sm.registrationFileOnSlowStorage(planeInd, 'interp'), 'w');
         end
     end
 end

--- a/registration/reg2P.m
+++ b/registration/reg2P.m
@@ -377,7 +377,6 @@ if ops.interpolateAcrossPlanes && ~isempty(regFileBinLocation)
         delete(filename)
     end
 end
-end
 
 %%
 % compute outlier frames and xrange, yrange of registered frames

--- a/registration/reg2P.m
+++ b/registration/reg2P.m
@@ -213,9 +213,9 @@ while sm.hasData()
     % get the registration offsets for each frame
     if ops.doRegistration
         if ops.nonrigid
-            [dsall, ops1] = nonrigidOffsets(data, fileCounter, iplane0, ops, ops1);
+            [dsall, ops1] = nonrigidOffsets(data, lastPartition, fileCounter, iplane0, ops, ops1);
         else
-            [dsall, ops1] = rigidOffsets(data, fileCounter, iplane0, ops, ops1);
+            [dsall, ops1] = rigidOffsets(data, lastPartition, fileCounter, iplane0, ops, ops1);
         end
     end
 

--- a/registration/reg2P.m
+++ b/registration/reg2P.m
@@ -1,4 +1,7 @@
-function ops1 = reg2P(ops)
+function ops1 = reg2P(sm)
+
+ops = sm.options;
+
 %%
 ops.doRegistration  = getOr(ops, {'doRegistration'}, 1); % register tiffs?
 
@@ -9,9 +12,10 @@ else
 end
 
 ops = buildRegOps(ops);
+planesToProcess = ops.planesToProcess;
 % --- number of planes in recording and number of channels --- %
 nplanes        = ops.nplanes;
-numPlanes          = length(ops.planesToProcess); % # of planes to process
+numPlanes          = length(planesToProcess); % # of planes to process
 % which channel is the functional channel
 ichannel           = getOr(ops, {'gchannel'}, 1);
 % which channel is the non-functional channel
@@ -29,15 +33,19 @@ if red_mean
     disp('computing mean RED image if ~isempty(db.expred)');
 end
 
+% Save options back to storage manager
+sm.options = ops;
+
 BiDiPhase              = ops.BiDiPhase;
 
-fs = ops.fsroot;
+% fs = ops.fsroot;
 
 %% find the mean frame after aligning a random subset
 
 % check if there are tiffs in directory
+fileName = sm.getFirstFile();
 try
-    IMG = loadFramesBuff(fs{1}(1).name, 1, 1, 1);
+    IMG = loadFramesBuff(fileName, 1, 1, 1);
 catch
     error('could not find any tif or tiff, check your path');
 end
@@ -50,11 +58,11 @@ ops.Lx = Lx;
 
 if ops.doRegistration
     % get frames for initial registration
-    IMG = GetRandFrames(fs, ops);
+    IMG = GetRandFrames(sm, ops);
     if isempty(IMG)
         error('ERROR: There are too few frames per plane for processing!');
     end
-    
+
     % from random frames get scaling factor (if uint16, scale by 2)
     if ~isfield(ops, 'scaleTiff')
         if max(IMG(:)) > 2^15
@@ -63,7 +71,7 @@ if ops.doRegistration
             ops.scaleTiff = 1;
         end
     end
-    
+
     % compute phase shifts from bidirectional scanning
     if ops.dobidi
         ops.BiDiPhase = BiDiPhaseOffsets(IMG);
@@ -77,38 +85,38 @@ if ops.doRegistration
     if ops.nonrigid
         ops = MakeBlocks(ops);
     end
-    
+
     % for each plane: align chosen frames to average to generate target image
-    ops1 = cell(numPlanes, size(xFOVs,2));
+    ops1 = cell(numPlanes, size(xFOVs, 2));
     for i = 1:numPlanes
-        for l = 1:size(xFOVs,2)
+        for l = 1:size(xFOVs, 2)
             if ops.nonrigid && ~(ops.alignAcrossPlanes || ops.interpolateAcrossPlanes)
-                ops1{i} = nonrigidAlignIterative(squeeze(IMG(:,:,ops.planesToProcess(i),:)), ops);
+                ops1{i} = nonrigidAlignIterative(squeeze(IMG(:, :, planesToProcess(i), :)), ops);
             else
-                ops1{i,l} = alignIterative(single(squeeze(IMG(yFOVs(:,l),xFOVs(:,l),...
-                    ops.planesToProcess(i),:))), ops);
+                ops1{i, l} = alignIterative(single(squeeze(IMG(yFOVs(:, l), xFOVs(:, l), ...
+                    planesToProcess(i), :))), ops);
             end
         end
-        fprintf('target image acquired for plane %d\n', ops.planesToProcess(i));
+        fprintf('target image acquired for plane %d\n', planesToProcess(i));
     end
-    
+
     if ops.alignTargetImages % align target images of all planes to each other
         % (reasonable only if interplane distance during imaging was small)
         newTargets = getImgOverPlanes(ops1);
         for i = 1:length(ops.planesToInterpolate)
-            for l = 1:size(xFOVs,2)
-                ops1{ops.planesToInterpolate(i),l}.mimg = newTargets(:,:,i,l);
+            for l = 1:size(xFOVs, 2)
+                ops1{ops.planesToInterpolate(i), l}.mimg = newTargets(:, :, i, l);
             end
         end
     end
-    
+
     % display target image
     if ops.fig && ops.showTargetRegistration
-        PlotRegMean(ops1,ops);
+        PlotRegMean(ops1, ops);
         drawnow
     end
     clear IMG
-    
+
 else   % don't recompute mean image
     ops1 = cell(numPlanes, 1);
     for i = 1:numPlanes
@@ -119,7 +127,7 @@ end
 
 %% initialize mean imgs and shifts
 for i = 1:numPlanes
-    for j = 1:size(xFOVs,2)
+    for j = 1:size(xFOVs, 2)
         if red_mean || red_align
             ops1{i,j}.mimgRED       = zeros(ops1{i,j}.Ly, ops1{i,j}.Lx);
         end
@@ -135,10 +143,11 @@ for i = 1:numPlanes
     end
 end
 
+sm.options = ops;
+sm.resetCurrentEntry();
+
 %% open files for registration
-
-[ops1, fid, fidRED, fidIntpol] = openBinFiles(ops, ops1, red_binary);
-
+[ops1, fid, fidRED, fidIntpol] = openBinFiles(sm, ops1, red_binary);
 
 %%
 tic
@@ -146,140 +155,149 @@ tic
 % if two consecutive files have as many bytes, they have as many frames
 nbytes = 0;
 
-xyValid = true(Ly,Lx);
-for k = 1:length(fs)
-    % in case different experiments have different numbers of channels
-    if ~isempty(ops.expts)
-        if ismember(ops.expts(k), getOr(ops, 'expred', []))
-            nchannels_expt = ops.nchannels_red;
+xyValid = true(Ly, Lx);
+sm.resetCurrentEntry();
+lastPartition = -1;
+fileCounter = 0;
+tempTiffPath = sm.getOr('temp_tiff');
+
+while sm.hasData()
+    [fileName, fileInfo] = sm.getFile();
+    fileCounter = fileCounter + 1;
+
+    if fileInfo.partition ~= lastPartition
+        iplane0 = 1:1:ops.nplanes; % identity of planes for first frames in tiff file
+                                   % reset for each new partition
+
+        nchannels_expt = sm.getNumChannels();
+        if nchannels_expt > 1
+            red_mean_expt = red_mean;
         else
-            nchannels_expt = ops.nchannels;
+            red_mean_expt = 0;
         end
-    else
-        nchannels_expt = ops.nchannels;
-    end
-    if nchannels_expt > 1
-        red_mean_expt  = red_mean;
-    else
-        red_mean_expt  = 0;
-    end
-    
-    if red_align
-        reg_channel = rchannel;
-    else
-        reg_channel = ichannel;
-    end
-        
-    % initialize frame count
-    for i = 1:numel(ops1)
-        ops1{i}.Nframes(k)     = 0;
-    end
-    
-    iplane0 = 1:1:ops.nplanes; % identity of planes for first frames in tiff file
-    for j = 1:length(fs{k})
-        % only compute number of frames if size of tiff is different
-        % from previous tiff
-        if abs(nbytes - fs{k}(j).bytes)>1e3
-            nbytes = fs{k}(j).bytes;
-            nFr = nFramesTiff(fs{k}(j).name);
-        end
-        if mod(nFr, nchannels_expt) ~= 0
-            fprintf('  WARNING: number of frames in tiff (%d) is NOT a multiple of number of channels!\n', j);
-        end
-                
-        iplane0 = mod(iplane0-1, numPlanes) + 1;
-        % only load frames of registration channel
-        data = loadFramesBuff(fs{k}(j).name, reg_channel, nFr, nchannels_expt, ops.temp_tiff);
-        if ~isempty(ops.temp_tiff)
-            tiff_file = ops.temp_tiff;
+
+        if red_align
+            reg_channel = rchannel;
         else
-            tiff_file = fs{k}(j).name;
+            reg_channel = ichannel;
         end
-        if abs(BiDiPhase) > 0; data = ShiftBiDi(BiDiPhase, data, Ly, Lx); end
-        
-        % get the registration offsets for each frame
-        if ops.doRegistration
-            if ops.nonrigid
-                [dsall, ops1] = nonrigidOffsets(data, k, j, iplane0, ops, ops1);
-            else
-                [dsall, ops1] = rigidOffsets(data, k, j, iplane0, ops, ops1);
-            end
+
+        % initialize frame count
+        for i = 1:numel(ops1)
+            ops1{i}.Nframes(fileInfo.partition)     = 0;
         end
-        
-        if ops.alignAcrossPlanes
-            if rem(j,5)==1
-                fprintf('Set %d, tiff %d done in time %2.2f \n', k, j, toc)
-            end
-            iplane0 = iplane0 - nFr/nchannels_expt;
-            continue;
-        end
-        
-        if ops.doRegistration
-            % if aligning by the red channel, data needs to be reloaded as the green channel
-            if red_align
-                data_red = data;
-                data = loadFramesBuff(tiff_file, ichannel, nFr, nchannels_expt, ops.temp_tiff);
-                if abs(BiDiPhase) > 0; data = ShiftBiDi(BiDiPhase, data, Ly, Lx);  end
-            end
-            % load red channel for red binary file if not already loaded for red alignment
-            if red_mean_expt && ~red_align
-                data_red = loadFramesBuff(tiff_file, rchannel, nFr, nchannels_expt, ops.temp_tiff);
-                if abs(BiDiPhase) > 0; data_red = ShiftBiDi(BiDiPhase, data_red, Ly, Lx); end
-            end
-            % align the frames according to the registration offsets
-            if ops.nonrigid
-                [dreg, xyValid] = nonrigidMovie(data, ops, dsall, xyValid);
-            else
-                dreg = rigidMovie(data, ops1, dsall, yFOVs, xFOVs);
-            end
-            
-            if red_mean_expt || red_align
-                if ops.nonrigid
-                    [dreg2, xyValid] = nonrigidMovie(data_red, ops, dsall, xyValid);
-                else
-                    dreg2 = rigidMovie(data_red, ops1, dsall, yFOVs, xFOVs);
-                end
-            end
+        lastPartition = fileInfo.partition;
+    end
+
+    % only compute number of frames if size of tiff is different
+    % from previous tiff
+    if abs(nbytes - fileInfo.bytes) > 1e3
+        nbytes = fileInfo.bytes;
+        nFr = nFramesTiff(fileName);
+    end
+    if mod(nFr, nchannels_expt) ~= 0
+        fprintf('  WARNING: number of frames in tiff (%d) is NOT a multiple of number of channels!\n', nchannels_expt);
+    end
+    iplane0 = mod(iplane0-1, numPlanes) + 1;
+    % only load frames of registration channel
+    data = loadFramesBuff(fileName, reg_channel, nFr, nchannels_expt, tempTiffPath);
+    if ~isempty(tempTiffPath)
+        tiff_file = tempTiffPath;
+    else
+        tiff_file = fileName;
+    end
+    if abs(BiDiPhase) > 0
+        data = ShiftBiDi(BiDiPhase, data, Ly, Lx);
+    end
+
+    % get the registration offsets for each frame
+    if ops.doRegistration
+        if ops.nonrigid
+            [dsall, ops1] = nonrigidOffsets(data, fileCounter, iplane0, ops, ops1);
         else
-            dreg = data;
+            [dsall, ops1] = rigidOffsets(data, fileCounter, iplane0, ops, ops1);
         end
-        
-        % write dreg to bin file+
-        for i = 1:numPlanes
-            ifr0 = iplane0(ops.planesToProcess(i));
-            indframes = ifr0:nplanes:size(data,3);
-            for l = 1:size(xFOVs,2)
-                dwrite = dreg(yFOVs(:,l),xFOVs(:,l),indframes);
-                dwrite = int16(dwrite / ops.scaleTiff);
-                fwrite(fid{i,l}, dwrite, 'int16');
-                ops1{i,l}.mimg1 = ops1{i,l}.mimg1 + sum(dwrite,3);
-                
-                if red_mean_expt || red_align
-                    dwrite = dreg2(yFOVs(:,l),xFOVs(:,l),indframes);
-                    if ops.scaleTiff>1
-                        dwrite = int16(dwrite / ops.scaleTiff);
-                    end
-                    ops1{i,l}.mimgRED = ops1{i,l}.mimgRED + sum(dwrite,3);
-                end
-                if red_binary
-                    fwrite(fidRED{i,l}, dwrite, 'int16');
-                end
-            end
+    end
+
+    if ops.alignAcrossPlanes
+        if rem(fileCounter, 5) == 1
+            fprintf('Set %d, tiff %d done in time %2.2f \n', lastPartition, fileCounter, toc);
         end
-        
-        
-        if rem(j,5)==1
-            fprintf('Set %d, tiff %d done in time %2.2f \n', k, j, toc)
-        end
-        
-        %keyboard;
         iplane0 = iplane0 - nFr/nchannels_expt;
+        continue;
     end
+
+    if ops.doRegistration
+        % if aligning by the red channel, data needs to be reloaded as the green channel
+        if red_align
+            data_red = data;
+            data = loadFramesBuff(tiff_file, ichannel, nFr, nchannels_expt, tempTiffPath);
+            if abs(BiDiPhase) > 0
+                data = ShiftBiDi(BiDiPhase, data, Ly, Lx);
+            end
+        end
+        % load red channel for red binary file if not already loaded for red alignment
+        if red_mean_expt && ~red_align
+            data_red = loadFramesBuff(tiff_file, rchannel, nFr, nchannels_expt, tempTiffPath);
+            if abs(BiDiPhase) > 0
+                data_red = ShiftBiDi(BiDiPhase, data_red, Ly, Lx);
+            end
+        end
+        % align the frames according to the registration offsets
+        if ops.nonrigid
+            [dreg, xyValid] = nonrigidMovie(data, ops, dsall, xyValid);
+        else
+            dreg = rigidMovie(data, ops1, dsall, yFOVs, xFOVs);
+        end
+
+        if red_mean_expt || red_align
+            if ops.nonrigid
+                [dreg2, xyValid] = nonrigidMovie(data_red, ops, dsall, xyValid);
+            else
+                dreg2 = rigidMovie(data_red, ops1, dsall, yFOVs, xFOVs);
+            end
+        end
+    else
+        dreg = data;
+    end
+
+    k = fileInfo.partition;
+
+    % write dreg to bin file+
+    for i = 1:numPlanes
+        ifr0 = iplane0(planesToProcess(i));
+        indframes = ifr0:nplanes:size(data, 3);
+        for l = 1:size(xFOVs, 2)
+            dwrite = dreg(yFOVs(:, l), xFOVs(:, l), indframes);
+            dwrite = int16(dwrite / ops.scaleTiff);
+            fwrite(fid{i, l}, dwrite, 'int16');
+            ops1{i, l}.mimg1 = ops1{i, l}.mimg1 + sum(dwrite, 3);
+
+            if red_mean_expt || red_align
+                dwrite = dreg2(yFOVs(:, l), xFOVs(:, l), indframes);
+                if ops.scaleTiff > 1
+                    dwrite = int16(dwrite / ops.scaleTiff);
+                end
+                ops1{i, l}.mimgRED = ops1{i, l}.mimgRED + sum(dwrite, 3);
+            end
+            if red_binary
+                fwrite(fidRED{i, l}, dwrite, 'int16');
+            end
+        end
+    end
+
+    if rem(fileCounter, 5) == 1
+        fprintf('Set %d, tiff %d done in time %2.2f \n', lastPartition, fileCounter, toc);
+    end
+
+    iplane0 = iplane0 - nFr/nchannels_expt;
 end
+
+sm.options = ops;
 
 if ops.alignAcrossPlanes && ops.doRegistration % align each frame with the best matching target image
     if ops.nonrigid
-        [ops1, planesToInterp] = registerBlocksAcrossPlanes(ops1, ops, fid, fidIntpol);
+        [ops1, planesToInterp] = registerBlocksAcrossPlanes(ops1, sm, fid, fidIntpol);
     else
         [ops1, planesToInterp] = registerAcrossPlanes(ops1, ops, fid, fidIntpol);
     end
@@ -308,10 +326,8 @@ for i = 1:numel(ops1)
     end
 end
 
-%%
-
 % get mean of first and last frames in block (to check for drift)
-if ~isempty(ops.nimgbegend) && ops.nimgbegend>0
+if ~isempty(ops.nimgbegend) && ops.nimgbegend > 0
     for i = 1:numel(ops1)
         fid{i}           = fopen(ops1{i}.RegFile, 'r');
         ops1{i} = getBlockBegEnd(fid{i}, ops1{i}); % get mean of first and last frames in block (to check for drift)
@@ -319,53 +335,48 @@ if ~isempty(ops.nimgbegend) && ops.nimgbegend>0
     end
 end
 
-
-% write registered tiffs to disk if ~isempty(ops.RegFileTiffLocation)
-if ~isempty(ops.RegFileTiffLocation)
+% write registered tiffs to disk if ~isempty(sm.getOr('RegFileTiffLocation'))
+if ~isempty(sm.getOr('RegFileTiffLocation'))
     for i = 1:numel(ops1)
         fid{i}           = fopen(ops1{i}.RegFile, 'r');
-        ops1{i} = write_reg_to_tiff(fid{i}, ops1{i}, i, 0);
+        write_reg_to_tiff(fid{i}, ops1{i}, i, 0, sm);
         fclose(fid{i});
-        
+
         if red_binary
             fidRED{i}           = fopen(ops1{i}.RegFile2, 'r');
-            ops1{i} = write_reg_to_tiff(fidRED{i}, ops1{i}, i, 1);
+            write_reg_to_tiff(fidRED{i}, ops1{i}, i, red_binary, sm);
             fclose(fidRED{i});
-        end   
-    end
-end
-
-% copy binary file if ~isempty(ops.RegFileBinLocation)
-if ~isempty(ops.RegFileBinLocation)
-    copyBinFile(ops1);
-end
-
-if ops.interpolateAcrossPlanes == 1 && ~isempty(ops.RegFileBinLocation)
-    for i = 1:numel(ops1)
-        folder = fullfile(ops1{i}.RegFileBinLocation, ops1{i}.mouse_name, ...
-            ops1{i}.date, ops.CharSubDirs, 'interpolated');
-        filename = fullfile(folder, ...
-            sprintf('%s_%s_%s_plane%d.bin', ops.mouse_name, ops.date, ...
-            ops.CharSubDirs, i));
-        if ismember(i, planesToInterp)
-            fidCopy = fopen(ops1{i}.RegFile, 'w');
-            fidOrig = fopen(filename, 'r');
-            sz = ops1{i}.Lx * ops1{i}.Ly;
-            parts = ceil(sum(ops1{i}.Nframes) / 2000);
-            for p = 1:parts
-                toRead = 2000;
-                if p == parts
-                    toRead = sum(ops1{i}.Nframes) - 2000 * (parts-1);
-                end
-                data = fread(fidOrig,  sz*toRead, '*int16');
-                fwrite(fidCopy, data, class(data));
-            end
-            fclose(fidCopy);
-            fclose(fidOrig);
-        else
-            delete(filename)
         end
     end
+end
+
+regFileBinLocation = sm.getOr('RegFileBinLocation');
+if ~isempty(regFileBinLocation)
+    copyBinFile(ops1, sm);
+end
+
+if ops.interpolateAcrossPlanes && ~isempty(regFileBinLocation)
+    filename = sm.registrationFileOnSlowStorage(i, 'interp');
+
+    if ismember(i, planesToInterp)
+        fidCopy = fopen(ops1{i}.RegFile, 'w');
+        fidOrig = fopen(filename, 'r');
+        sz = ops1{i}.Lx * ops1{i}.Ly;
+        parts = ceil(sum(ops1{i}.Nframes) / 2000);
+        for p = 1:parts
+            toRead = 2000;
+            if p == parts
+                toRead = sum(ops1{i}.Nframes) - 2000 * (parts-1);
+            end
+            data = fread(fidOrig,  sz*toRead, '*int16');
+            fwrite(fidCopy, data, class(data));
+        end
+        fclose(fidCopy);
+        fclose(fidOrig);
+    else
+        delete(filename)
+    end
+end
 end
 
 %%
@@ -379,15 +390,8 @@ else
     end
 end
 
-savepath = sprintf('%s/', ops.ResultsSavePath);
-if ~exist(savepath, 'dir')
-    mkdir(savepath)
-end
-save(sprintf('%s/regops_%s_%s.mat', ops.ResultsSavePath, ...
-    ops.mouse_name, ops.date),  'ops1')
-
-
-%save(sprintf('%s/F_%s_%s_plane%d.mat', ops.ResultsSavePath, ...
-%   ops.mouse_name, ops.date, iplane), 'ops')
+sm.options = ops;
+%options = ops1;
+sm.saveRegistrationOptions(ops1);
 
 %%

--- a/registration/registerBlocksAcrossPlanes.m
+++ b/registration/registerBlocksAcrossPlanes.m
@@ -1,20 +1,20 @@
 function [ops1, planesToInterp, xyValid] = registerBlocksAcrossPlanes( ...
-    ops1, ops, fid, fidIntpol)
+    ops1, sm, fid, fidIntpol)
 
+ops = sm.options;
 nplanes = getOr(ops, {'nplanes'}, 1);
 planesToInterpolate = getOr(ops, {'planesToInterpolate'}, 1:nplanes);
 ichannel = getOr(ops, {'gchannel'}, 1);
 BiDiPhase = getOr(ops, {'BiDiPhase'}, 0);
 RegFileBinLocation = getOr(ops, {'RegFileBinLocation'}, []);
 interpolateAcrossPlanes = getOr(ops, {'interpolateAcrossPlanes'}, false);
-fs = ops.fsroot;
 numBlocks = prod(ops.numBlocks);
 
-% in order to determine optimal shifts in z at each time point, collect 
+% in order to determine optimal shifts in z at each time point, collect
 % registration offsets and correlations of all frames with all target images
-corrsAll = []; % [time x alignedPlanes (numPlanes) x 
+corrsAll = []; % [time x alignedPlanes (numPlanes) x
                %  targetPlanes (length(planesToInterpolate)) x numBlocks]
-dsAllPlanes = []; % [time x [x,y] x alignedPlanes (numPlanes) x 
+dsAllPlanes = []; % [time x [x,y] x alignedPlanes (numPlanes) x
                   %  targetPlanes (length(planesToInterpolate)) x numBlocks];
 for i = planesToInterpolate
     % reshape ds to [frames x 2 x planes x numBlocks], and
@@ -40,7 +40,7 @@ for i = planesToInterpolate
     end
     ops1{i}.DS = ds; % [time x 2 x nplanes x numBlocks]
     ops1{i}.CorrFrame = corrs; % [time x nplanes x numBlocks]
-    
+
     if ~isempty(dsAllPlanes) && size(ds,1)<size(dsAllPlanes,1)
         ds(end+1:size(dsAllPlanes,1),:,:,:) = NaN;
         corrs(end+1:size(corrsAll,1),:,:) = NaN;
@@ -157,7 +157,7 @@ for i = setdiff(1:nplanes, planesToInterpolate)
     ds = ops1{i}.DS;
     indframes(size(ds,1)+1:end) = [];
     dsall(indframes,:,:) = ds;
-    
+
     ops1{i}.planeInterpolated = 0;
     up = false(size(ds,1), nplanes);
     up(:,i) = true;
@@ -175,7 +175,7 @@ for i = 1:length(planesToInterpolate)
         length(planesToInterpolate);
     linearInd = sub2ind(size(ds(:,:,:,1)), subscripts(:,1), subscripts(:,2), ...
         subscripts(:,3));
-    
+
     if ismember(i, indInterpolate)
         prof = eye(nplanes);
         prof(prof==0) = NaN;
@@ -196,7 +196,7 @@ for i = 1:length(planesToInterpolate)
     nanInds = isnan(values(:,1,1));
     values(nanInds,:,:) = [];
     ops1{planesToInterpolate(i)}.DS = values;
-    
+
     if ismember(i, indInterpolate)
         ops1{planesToInterpolate(i)}.planeInterpolated = 1;
         ops1{planesToInterpolate(i)}.usedPlanes = up;
@@ -213,7 +213,7 @@ for i = 1:length(planesToInterpolate)
     ap(ap<planesToInterpolate(1)) = planesToInterpolate(1);
     ap(ap>planesToInterpolate(end)) = planesToInterpolate(end);
     ops1{planesToInterpolate(i)}.alignedToPlanes = ap;
-    
+
     ops =  ops1{planesToInterpolate(i)};
     ops.CorrFrame(repmat(~ops.usedPlanes,1,1,numBlocks)) = NaN;
     ops.CorrFrame = nanmean(nanmean(ops.CorrFrame,2),3); % average correlations across all used planes and all blocks
@@ -228,97 +228,103 @@ t2 = 0;
 % if two consecutive files have as many bytes, they have as many frames
 nbytes = 0;
 xyValid = true(ops.Ly, ops.Lx);
-for k = 1:length(fs)
-    dataPrev = zeros(ops.Ly, ops.Lx, nplanes, 'int16');
-    iplane0 = 1:1:ops.nplanes;
-    t1 = 0;
-    for j = 1:length(fs{k})
-        if abs(nbytes - fs{k}(j).bytes)>1e3
-            nbytes = fs{k}(j).bytes;
-            nFr = nFramesTiff(fs{k}(j).name);
+lastPartition = -1;
+fileCounter = 0;
+while sm.hasData()
+    [fileName, fileInfo] = sm.getFile();
+    fileCounter = fileCounter + 1;
+
+    if fileInfo.partition ~= lastPartition
+        dataPrev = zeros(ops.Ly, ops.Lx, nplanes, 'int16');
+        iplane0 = 1:1:ops.nplanes;
+        t1 = 0;
+    end
+    if abs(nbytes - fileInfo.bytes) > 1e3
+        nbytes = fileInfo.bytes;
+        nFr = nFramesTiff(fileName);
+    end
+    iplane0 = mod(iplane0-1, nplanes) + 1;
+
+    if mod(nFr, ops.nchannels) ~= 0
+        fprintf('  WARNING: number of frames in tiff (%d) is NOT a multiple of number of channels!\n', fileCounter);
+    end
+    % load frames of all planes
+    ichanset = [ichannel; nFr; ops.nchannels];
+    data = loadFramesBuff(fileName, ichanset(1), ichanset(2), ichanset(3));
+    if BiDiPhase
+        yrange = 2:2:Ly;
+        if BiDiPhase>0
+            data(yrange, (1+BiDiPhase):Lx,:) = data(yrange, 1:(Lx-BiDiPhase),:);
+        else
+            data(yrange, 1:Lx+BiDiPhase,:) = data(yrange, 1-BiDiPhase:Lx,:);
         end
-        iplane0 = mod(iplane0-1, nplanes) + 1;
-        
-        if mod(nFr, ops.nchannels) ~= 0
-            fprintf('  WARNING: number of frames in tiff (%d) is NOT a multiple of number of channels!\n', j);
-        end
-        % load frames of all planes
-        ichanset = [ichannel; nFr; ops.nchannels];
-        data = loadFramesBuff(fs{k}(j).name, ichanset(1), ichanset(2), ichanset(3));
-        if BiDiPhase
-            yrange = 2:2:Ly;
-            if BiDiPhase>0
-                data(yrange, (1+BiDiPhase):Lx,:) = data(yrange, 1:(Lx-BiDiPhase),:);
-            else
-                data(yrange, 1:Lx+BiDiPhase,:) = data(yrange, 1-BiDiPhase:Lx,:);
-            end
-        end
-        
-        % align frames according to determined registration offsets
-        [dreg, xyValid] = BlockRegMovie(data, ops, ...
-            dsall(t1+t2+(1:size(data,3)),:,:), xyValid);
-        
-        % for each plane, write aligned movie to bin file+
-        for i = 1:nplanes
-            ifr0 = iplane0(ops.planesToProcess(i));
-            indframes = ifr0:nplanes:size(data,3);
-            dwrite = dreg(:,:,indframes);
-            fwrite(fid{i}, dwrite, class(data));
-            
-            ops1{i}.mimg1 = ops1{i}.mimg1 + sum(dwrite,3);
-        end
-        
-        if interpolateAcrossPlanes && ~isempty(RegFileBinLocation)
-            % use frames of plane that match best to target image of
-            % current plane and average across similar planes
-            dataNext = [];
-            for i = indInterpolate
-                ind1 = iplane0(planesToInterpolate(i)) : nplanes : size(data,3);
-                sh = shifts(ceil((t1+t2)/nplanes + (1:length(ind1))));
-                uniqueShifts = unique(sh);
-                dwrite = zeros(size(dreg,1),size(dreg,2),length(ind1));
-                for s = uniqueShifts
-                    planesInv = find(~isnan(profiles(:,i-s)))';
-                    diffs = planesInv - i;
-                    for pl = 1:length(planesInv)
-                        ind2 = ind1 + diffs(pl); % smallest possible value: -nplanes+1,
-                        % largest possible values: size(dreg,3)+nplanes
-                        ind2(sh~=s) = [];
-                        weight = profiles(planesInv(pl),i-s);
-                        if ind2(1)<1 % frame is part of previously loaded tiff file (can happen if frames per tiff are not mupltiple of planes)
-                            dwrite(:,:,1) = dwrite(:,:,1) + ...
-                                weight .* double(dataPrev(:,:,end-ind2(1)));
-                            ind2(1) = [];
-                        end
-                        if ind2(end)>size(dreg,3) % frame is part of upcoming tiff file
-                            if j<length(fs{k})
-                                if isempty(dataNext) % load first few frames of next tiff and register them
-                                    ichanset = [ichannel; nplanes; ops.nchannels];
-                                    data = loadFramesBuff(fs{k}(j+1).name, ...
-                                        ichanset(1), ichanset(2), ichanset(3));
-                                    if BiDiPhase
-                                        yrange = 2:2:Ly;
-                                        if BiDiPhase>0
-                                            data(yrange, (1+BiDiPhase):Lx,:) = data(yrange, 1:(Lx-BiDiPhase),:);
-                                        else
-                                            data(yrange, 1:Lx+BiDiPhase,:) = data(yrange, 1-BiDiPhase:Lx,:);
-                                        end
-                                    end
-                                    dataNext = register_movie(data, ops, ...
-                                        dsall((t1+t2) + size(dreg,3) ...
-                                        + (1:nplanes),:));
-                                end
-                                dwrite(:,:,end) = dwrite(:,:,end) + weight .*...
-                                    double(dataNext(:,:,ind2(end)-size(dreg,3)));
-                            end
-                            ind2(end) = [];
-                        end
-                        dwrite(:,:,ceil(ind2/nplanes)) = dwrite(:,:,ceil(ind2/nplanes)) + ...
-                            weight .* double(dreg(:,:,ind2));
+    end
+
+    % align frames according to determined registration offsets
+    [dreg, xyValid] = BlockRegMovie(data, ops, ...
+        dsall(t1+t2+(1:size(data,3)),:,:), xyValid);
+
+    % for each plane, write aligned movie to bin file+
+    for i = 1:nplanes
+        ifr0 = iplane0(ops.planesToProcess(i));
+        indframes = ifr0:nplanes:size(data,3);
+        dwrite = dreg(:,:,indframes);
+        fwrite(fid{i}, dwrite, class(data));
+
+        ops1{i}.mimg1 = ops1{i}.mimg1 + sum(dwrite,3);
+    end
+
+    if interpolateAcrossPlanes && ~isempty(RegFileBinLocation)
+        % use frames of plane that match best to target image of
+        % current plane and average across similar planes
+        dataNext = [];
+        for i = indInterpolate
+            ind1 = iplane0(planesToInterpolate(i)) : nplanes : size(data,3);
+            sh = shifts(ceil((t1+t2)/nplanes + (1:length(ind1))));
+            uniqueShifts = unique(sh);
+            dwrite = zeros(size(dreg,1),size(dreg,2),length(ind1));
+            for s = uniqueShifts
+                planesInv = find(~isnan(profiles(:,i-s)))';
+                diffs = planesInv - i;
+                for pl = 1:length(planesInv)
+                    ind2 = ind1 + diffs(pl); % smallest possible value: -nplanes+1,
+                    % largest possible values: size(dreg,3)+nplanes
+                    ind2(sh~=s) = [];
+                    weight = profiles(planesInv(pl),i-s);
+                    if ind2(1)<1 % frame is part of previously loaded tiff file (can happen if frames per tiff are not mupltiple of planes)
+                        dwrite(:, :, 1) = dwrite(:, :, 1) + ...
+                            weight .* double(dataPrev(:, :, end-ind2(1)));
+                        ind2(1) = [];
                     end
+                    if ind2(end) > size(dreg, 3) % frame is part of upcoming tiff file
+                        nextFileName = sm.getNextFile();
+                        if ~isempty(nextFileName)
+                            if isempty(dataNext) % load first few frames of next tiff and register them
+                                ichanset = [ichannel; nplanes; ops.nchannels];
+                                data = loadFramesBuff(nextFileName, ...
+                                    ichanset(1), ichanset(2), ichanset(3));
+                                if BiDiPhase
+                                    yrange = 2:2:Ly;
+                                    if BiDiPhase > 0
+                                        data(yrange, (1+BiDiPhase):Lx, :) = data(yrange, 1:(Lx-BiDiPhase), :);
+                                    else
+                                        data(yrange, 1:Lx+BiDiPhase, :) = data(yrange, 1-BiDiPhase:Lx, :);
+                                    end
+                                end
+                                dataNext = register_movie(data, ops, ...
+                                    dsall((t1+t2) + size(dreg,3) ...
+                                    + (1:nplanes),:));
+                            end
+                            dwrite(:, :, end) = dwrite(:, :, end) + weight .*...
+                                double(dataNext(:, :, ind2(end) - size(dreg, 3)));
+                        end
+                        ind2(end) = [];
+                    end
+                    dwrite(:, :, ceil(ind2/nplanes)) = dwrite(:, :, ceil(ind2/nplanes)) + ...
+                        weight .* double(dreg(:, :, ind2));
                 end
-                fwrite(fidIntpol{ops.planesToProcess(planesToInterpolate(i))}, dwrite, class(data));
             end
+            fwrite(fidIntpol{ops.planesToProcess(planesToInterpolate(i))}, dwrite, class(data));
         end
         dataPrev = dreg(:,:,end-nplanes+1:end);
         t1 = t1 + size(dreg,3);

--- a/run_pipeline.m
+++ b/run_pipeline.m
@@ -1,97 +1,93 @@
-function  run_pipeline(db, ops0)
+function run_pipeline_new(sm)
 
-% ops0.TileFactor (or db(iexp).TileFactor) can be set to multiply the number of default tiles for the neuropil
+% options.TileFactor (or db(iexp).TileFactor) can be set to multiply the number of default tiles for the neuropil
 
-ops0.splitROIs                      = getOr(ops0, {'splitROIs'}, 1);
-ops0.LoadRegMean                    = getOr(ops0, {'LoadRegMean'}, 0);
-ops0.getROIs                        = getOr(ops0, {'getROIs'}, 1);   % whether to run the optimization
-ops0.getSVDcomps                    = getOr(ops0, {'getSVDcomps'}, 0);   % whether to save SVD components to disk for later processing
+options = sm.options;
+options.splitROIs                      = getOr(options, {'splitROIs'}, 1);
+options.LoadRegMean                    = getOr(options, {'LoadRegMean'}, 0);
+options.getROIs                        = getOr(options, {'getROIs'}, 1);   % whether to run the optimization
+options.getSVDcomps                    = getOr(options, {'getSVDcomps'}, 0);   % whether to save SVD components to disk for later processing
 
-ops0                                = build_ops3(db, ops0);
-if ~isfield(ops0, 'diameter') || isempty(ops0.diameter)
+%options                                = build_ops3(db, options);
+% options initialization is done elsewhere
+options.diameter = sm.getOr('diameter', 8*sm.getOr('zoom'));
+
+if isempty(options.diameter)
     warning('you have not specified mean diameter of your ROIs')
     warning('for best performance, please set db(iexp).diameter for each experiment')
 end
-ops0.diameter                        = getOr(ops0, 'diameter', 8*ops0.zoom);
-ops0.clustrules.diameter             = ops0.diameter;
-ops0.clustrules                      = get_clustrules(ops0.clustrules);
+%options.diameter                        = getOr(options, 'diameter', 8*options.zoom);
+options.clustrules.diameter             = options.diameter;
+options.clustrules                      = get_clustrules(options.clustrules);
+
+% Save options back to storage manager
+sm.options = options;
 
 % this loads ops1 and checks if processed binary files exist
-opath = sprintf('%s/regops_%s_%s.mat', ops0.ResultsSavePath, ops0.mouse_name, ops0.date);
-processed = 1;
-if exist(opath, 'file')
-    load(opath);
-    for j = 1:numel(ops1)       
-       if ~exist(ops1{j}.RegFile, 'file') % check if the registered binary file exists
-          processed = 0; 
-       end
-    end
-else
-    processed = 0;
-end
+processed = sm.isRegistrationDone();
 
 % run reg2P if the binaries do not exist
 %%%% if tiffs have already been registered, set ops.doRegistration = 0
 %%%% and reg2P will just create binary file
 % ops1 are the settings and values from registration
-if processed==0
-    ops1 = reg2P(ops0);  % do registration
-else
+if processed
     disp('already registered binary found');
+    ops1 = sm.loadRegistrationOptions();
+else
+    ops1 = reg2P(sm);  % do registration
 end
 
 %%
-for i = [1:numel(ops1)]
-    ops         = ops1{i};    
+for i = 1:numel(ops1)
+    ops         = ops1{i};
 
-    % check if settings are different between ops and ops0
-    % ops0 settings are chosen over ops settings
-    ops         = opsChanges(ops, ops0);    
-    
+    % check if settings are different between ops and options
+    % options settings are chosen over ops settings
+    ops         = opsChanges(ops, options);
+
     ops.iplane  = i;
-    
-%     ops.ThScaling = 0.5;
-    
+
     if numel(ops.yrange)<10 || numel(ops.xrange)<10
         warning('valid range after registration very small, continuing to next plane')
         continue;
     end
-    
+
     if getOr(ops, {'getSVDcomps'}, 0)
         % extract and write to disk SVD comps (raw data)
-        ops    = get_svdcomps(ops);
+        ops    = get_svdcomps(ops, sm);
     end
-            
+
     if ops.getROIs
         % get sources in stat, and clustering images in res
-        [ops, stat, model]           = sourcery(ops);
+        [ops, stat, model]           = sourcery(ops, sm);
 
-        figure(10); clf;
+        if options.fig
+            figure(10); clf;
+        end
 
         % extract dF
         switch getOr(ops, 'signalExtraction', 'surround')
             case 'raw'
-                [ops, stat, Fcell, FcellNeu] = extractSignalsNoOverlaps(ops, model, stat);
+                [ops, stat, Fcell, FcellNeu] = extractSignalsNoOverlaps(ops, model, stat, sm); %#ok<ASGLU>
             case 'regression'
-                [ops, stat, Fcell, FcellNeu] = extractSignals(ops, model, stat);
+                [ops, stat, Fcell, FcellNeu] = extractSignals(ops, model, stat, sm); %#ok<ASGLU>
             case 'surround'
-                [ops, stat, Fcell, FcellNeu] = extractSignalsSurroundNeuropil2(ops, stat);
+                [ops, stat, Fcell, FcellNeu] = extractSignalsSurroundNeuropil2(ops, stat); %#ok<ASGLU>
         end
-        
+
         % apply user-specific clustrules to infer stat.iscell
-        stat                         = classifyROI(stat, ops.clustrules);
-        
-        
-        save(sprintf('%s/F_%s_%s_plane%d.mat', ops.ResultsSavePath, ...
-            ops.mouse_name, ops.date, ops.iplane),  'ops',  'stat',...
-            'Fcell', 'FcellNeu', '-v7.3')
+        stat                         = classifyROI(stat, ops.clustrules); %#ok<NASGU>
+
+
+        fileName = sm.getFileForPlane('f', ops.iplane);
+        save(fileName,  'ops',  'stat', 'Fcell', 'FcellNeu', '-v7.3');
     end
 
     fclose('all');
-    if ops.DeleteBin       
-         delete(ops.RegFile);        % delete temporary bin file
+    if ops.DeleteBin
+        delete(ops.RegFile);        % delete temporary bin file
     end
 end
 
 % clean up
-fclose all;
+fclose('all');

--- a/signalExtraction/extractSignals.m
+++ b/signalExtraction/extractSignals.m
@@ -1,4 +1,4 @@
-function [ops, stat, Fcell, FcellNeu]      = extractSignals(ops, m, stat)
+function [ops, stat, Fcell, FcellNeu]      = extractSignals(ops, m, stat, sm)
 
 ops.saveNeuropil = getOr(ops, 'saveNeuropil', 0);
 
@@ -19,7 +19,7 @@ covL = [m.LtL m.LtS; m.LtS' m.StS];
 
 % covLinv = inv(covL + 1e-4 * Ireg);
 % covLinv = covLinv ./ repmat(diag(covLinv), 1, size(covLinv,2));
-%% get signals  
+%% get signals
 
 nimgbatch = 2000;
 
@@ -38,27 +38,27 @@ end
 [Ly Lx] = size(ops.mimg1);
 
 mimg1 = ops.mimg1(ops.yrange, ops.xrange);
-% find indices of good clusters 
+% find indices of good clusters
 while 1
     data = fread(fid,  Ly*Lx*nimgbatch, '*int16');
     if isempty(data)
-       break; 
+       break;
     end
     data = reshape(data, Ly, Lx, []);
     data = data(ops.yrange, ops.xrange, :);
     data = single(data);
     NT   = size(data,3);
-    
+
     % process the data
     data = bsxfun(@minus, data, mimg1);
     data = my_conv2(data, ops.sig, [1 2]);
-    data = bsxfun(@rdivide, data, m.sdmov);    
+    data = bsxfun(@rdivide, data, m.sdmov);
     data = single(reshape(data, [], NT));
-    
+
     %
     Ftemp = zeros(Nk, NT, 'single');
     for k = 1:Nk
-       ipix = stat(k).ipix(:)'; 
+       ipix = stat(k).ipix(:)';
        if ~isempty(ipix)
            Ftemp(k,:) = stat(k).lam(:)' * data(ipix,:);
        end
@@ -66,14 +66,14 @@ while 1
     %
     StU         = S' * data;
     Fdeconv     = covL\cat(1, Ftemp, StU);
-    
+
     Fneu(:,ix + (1:NT))     = m.LtS * Fdeconv(1+Nk:end, :); % estimated neuropil
     F(:,ix + (1:NT))        = Fneu(:,ix + (1:NT)) + Fdeconv(1:Nk, :); % estimated ROI signal
-    
+
     if ops.saveNeuropil
         Ntraces(:,ix + (1:NT)) = Fdeconv(1+Nk:end, :);
     end
-    
+
     ix = ix + NT;
     if rem(ix, 3*NT)==0
         fprintf('Frame %d done in time %2.2f \n', ix, toc)
@@ -120,6 +120,6 @@ end
 
 if getOr(ops, 'saveNeuropil', 0)
     S = reshape(S, numel(ops.yrange), numel(ops.xrange), Nbasis);
-    save(sprintf('%s/NEU_%s_%s_plane%d.mat', ops.ResultsSavePath, ...
-        ops.mouse_name, ops.date, ops.iplane),  'ops', 'S', 'Ntraces', '-v7.3')
+    filePath = sm.getFileForPlane('neuropil', ops.iplane);
+    save(filePath, 'ops', 'S', 'Ntraces', '-v7.3');
 end

--- a/signalExtraction/extractSignalsNoOverlaps.m
+++ b/signalExtraction/extractSignalsNoOverlaps.m
@@ -1,4 +1,4 @@
-function [ops, stat, Fcell, FcellNeu]      = extractSignalsNoOverlaps(ops, m, stat)
+function [ops, stat, Fcell, FcellNeu]      = extractSignalsNoOverlaps(ops, m, stat, sm)
 
 ops.saveNeuropil = getOr(ops, 'saveNeuropil', 0);
 
@@ -34,14 +34,14 @@ for k = 1:Nk
     end
 end
 
-% add all pixels within X um 
+% add all pixels within X um
 if isfield(ops, 'exclFracCell') && ops.exclFracCell>0
     H       = fspecial('disk', round(ops.diameter * ops.exclFracCell));
     maskNeu = reshape(maskNeu, Ny, Nx);
     maskNeu = imfilter(maskNeu, H, 'replicate');
     maskNeu = single(maskNeu(:) > 1-1e-3);
 end
-%% get signals  
+%% get signals
 S    = bsxfun(@times, S, maskNeu(:));
 StS = S' * S;
 StS = StS + 1e-2 * eye(size(StS));
@@ -63,44 +63,44 @@ end
 [Ly Lx] = size(ops.mimg1);
 
 mimg1 = ops.mimg1(ops.yrange, ops.xrange);
-% find indices of good clusters 
+% find indices of good clusters
 while 1
     data = fread(fid,  Ly*Lx*nimgbatch, '*int16');
     if isempty(data)
-       break; 
+       break;
     end
     data = reshape(data, Ly, Lx, []);
     data = data(ops.yrange, ops.xrange, :);
     data = single(data);
     NT   = size(data,3);
-    
+
     % process the data
     data = bsxfun(@minus, data, mimg1);
     data = my_conv2(data, ops.sig, [1 2]);
-    data = bsxfun(@rdivide, data, m.sdmov);    
+    data = bsxfun(@rdivide, data, m.sdmov);
     data = single(reshape(data, [], NT));
-    
+
     %
     Ftemp = zeros(Nk, NT, 'single');
     for k = 1:Nk
-       ipix = stat(k).ipix(~stat(k).isoverlap)'; 
+       ipix = stat(k).ipix(~stat(k).isoverlap)';
        if ~isempty(ipix)
            Ftemp(k,:) = stat(k).lam(~stat(k).isoverlap)' * data(ipix,:);
        end
     end
     F(:,ix + (1:NT))    = Ftemp;
-    
+
     Tneu                = StS\(S' * data);
-    Ftemp2              = LtS * Tneu;    
+    Ftemp2              = LtS * Tneu;
     Fneu(:,ix + (1:NT)) = Ftemp2;
-    
+
 %     Fneu(:,ix + (1:NT))     = m.LtS * Fdeconv(1+Nk:end, :); % estimated neuropil
 %     F(:,ix + (1:NT))        = Fneu(:,ix + (1:NT)) + Fdeconv(1:Nk, :); % estimated ROI signal
-    
+
     if ops.saveNeuropil
         Ntraces(:,ix + (1:NT)) = Tneu;
     end
-    
+
     ix = ix + NT;
     if rem(ix, 3*NT)==0
         fprintf('Frame %d done in time %2.2f \n', ix, toc)
@@ -115,7 +115,7 @@ data = single(reshape(data, [], 1));
 scalefactors = nan(numel(stat),1);
 Ftemp = zeros(Nk, 1, 'single');
 for k = 1:Nk
-    ipix = stat(k).ipix(~stat(k).isoverlap)'; 
+    ipix = stat(k).ipix(~stat(k).isoverlap)';
     if ~isempty(ipix)
         Ftemp(k,:) = stat(k).lam(~stat(k).isoverlap)' * data(ipix,1);
         scalefactors(k) = mean(m.sdmov(ipix));
@@ -146,6 +146,6 @@ end
 
 if getOr(ops, 'saveNeuropil', 0)
     S = reshape(S, numel(ops.yrange), numel(ops.xrange), nBasis);
-    save(sprintf('%s/NEU_%s_%s_plane%d.mat', ops.ResultsSavePath, ...
-        ops.mouse_name, ops.date, ops.iplane),  'ops', 'S', 'Ntraces', '-v7.3')
+    filePath = sm.getFileForPlane('neuropil', ops.iplane);
+    save(filePath,  'ops', 'S', 'Ntraces', '-v7.3');
 end

--- a/tests/CortexLabStorageManagerTest.m
+++ b/tests/CortexLabStorageManagerTest.m
@@ -1,0 +1,344 @@
+%% Unit-tests for CortextLabStorageManager
+classdef CortexLabStorageManagerTest < matlab.unittest.TestCase
+
+    properties (Access=protected)
+
+        % Folder where data for this test is stored
+        % If empty, then some sample files will be downloaded
+        % from Google Drive. You can download the files yourself
+        % and then provide a path to the files. DataFolder
+        % should point to root folder, i.e. without
+        % animal/date/experiment information.
+        % Alternatively to setting the path in this file, you may set environment
+        % variable SUITE2P_TEST_DATA.
+        % If borh SUITE2P_TEST_DATA and DataFolder have values, then DataFolder has priority and
+        % will be used.
+        DataFolder
+
+        Options % initial static options
+    end
+
+    properties (Access=private)
+        downloadFiles = true
+    end
+
+    methods
+        function this = CortexLabStorageManagerTest()
+            testDataDir = getenv('SUITE2P_TEST_DATA');
+            if isempty(this.DataFolder) && isempty(testDataDir)
+                this.DataFolder = fullfile(tempdir, 'Suite2P-tests-CortexLabStorageManagerTest');
+                if ~exist(this.DataFolder, 'dir')
+                    mkdir(this.DataFolder);
+                end
+            else
+                if ~isempty(testDataDir)
+                    candidate = testDataDir;
+                end
+                if ~isempty(this.DataFolder)
+                    candidate = this.DataFolder;
+                end
+                this.DataFolder = candidate;
+
+                if exist(this.DataFolder, 'dir') ~= 0
+                    this.downloadFiles = false;
+                end
+            end
+        end
+    end
+
+    methods (TestClassSetup)
+        function prepareData(this)
+            if ~this.downloadFiles
+                return;
+            end
+
+            % Make DB structure
+            outputFolder = fullfile(this.DataFolder, 'M0', '2017-10-13', '4');
+            if ~exist(outputFolder, 'dir')
+                mkdir(outputFolder);
+            end
+
+            % download couple of files from GDrive
+            fprintf('Downloading files. This takes time...\n');
+            files = {'file_00002_00001.tif', '0B649boZqpYG1Mk9UM1FCZ0FfaFE';...
+                'file_00002_00002.tif', '0B649boZqpYG1OEZnV21ncDVNcVk';...
+                'file_00002_00003.tif', '0B649boZqpYG1Z3FkdmZYaEZlTDg'; ...
+                'file_00002_00004.tif', '0B649boZqpYG1MzI5Y1g5UXZneGs'; ...
+                'file_00002_00005.tif', '0B649boZqpYG1MW9ubURmTk9SQXM'; ...
+                };
+            options = weboptions('ContentType', 'raw');
+
+            for i = 1:size(files, 1)
+                fileName = files{i, 1};
+                fileUrl = sprintf('https://drive.google.com/uc?export=download&id=%s', files{i, 2});
+
+                fprintf('File %d/%d...', i, size(files, 1));
+
+                request = matlab.net.http.RequestMessage();
+                % First request will be redirected to information page about virus scanning
+                % We can get a confirmation code from an associated cookie file
+                [~, infos] = sendRequest(matlab.net.URI(fileUrl), request);
+                confirmCode = '';
+                for j = 1:length(infos('drive.google.com').cookies)
+                    if ~isempty(strfind(infos('drive.google.com').cookies(j).Name, 'download'))
+                        confirmCode = infos('drive.google.com').cookies(j).Value;
+                        break;
+                    end
+                end
+                newUrl = strcat(fileUrl, sprintf('&confirm=%s', confirmCode));
+                % We now need to send another request to get the file.
+                % However, Matlab doesn't download the whole Tiff file, but
+                % only one frame.
+                [~, ~, history] = sendRequest(matlab.net.URI(newUrl), request);
+
+                % Thus we must use log file information to find out a
+                % direct link and downalod it as raw file
+                ind = arrayfun(@(x) ~isempty(strfind(x.URI.Host, 'googleusercontent')), history);
+                ind = find(ind, 1);
+
+                imgData = webread(history(ind).URI.EncodedURI, options);
+                fid = fopen(fullfile(outputFolder, fileName), 'wb');
+                fwrite(fid, imgData);
+                fclose(fid);
+
+                fprintf('done\n');
+            end
+        end
+    end
+
+    methods (TestClassTeardown)
+        function cleanDataFolder(testCase)
+        end
+    end
+
+    methods(TestMethodSetup)
+        function initializeOptions(testCase)
+            testCase.Options = CortexLabStorageManagerTest.getDefaultOptions();
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function removeOptions(testCase)
+            testCase.Options = [];
+        end
+    end
+
+    methods (Test)
+        function testConstruction(testCase)
+            sm = CortexLabStorageManager(testCase.Options);
+        end
+
+        function testDefaultDataset(testCase)
+            sm = CortexLabStorageManager(testCase.Options);
+
+            dbEntry.mouseName = 'M0';
+            dbEntry.date = '2017-10-13';
+            dbEntry.experiments = [4];
+            dbEntry.diameter = 16;
+            dbEntry.nplanes = 1;
+            dbEntry.resultsSavePath = strcat(testCase.DataFolder, '-results');
+            dbEntry.rootStorage = testCase.DataFolder;
+            dbEntry.regFilePath = dbEntry.resultsSavePath;
+            dbEntry.RegFileBinLocation = strcat(testCase.DataFolder, '-out-registration-slow');
+            dbEntry.RegFileTiffLocation = '';
+            dbEntry.temp_tiff = tempname;
+
+            sm.addEntry(dbEntry);
+
+            testCase.verifyEqual(sm.getNumEntries(), 1);
+
+            sm.selectEntry(1);
+            run_pipeline(sm);
+            add_deconvolution(sm);
+
+            % now let's check that we have files in proper places
+            binFile = 'M0_2017-10-13_4_plane1.bin';
+            binExist = exist(fullfile(dbEntry.RegFileBinLocation, binFile), 'file') ~= 0;
+            testCase.verifyTrue(binExist);
+
+            % check bin is still on 'fast' storage
+            binExist = exist(fullfile(dbEntry.regFilePath, binFile), 'file') ~= 0;
+            testCase.verifyTrue(binExist);
+
+            % check output directory structure
+            trueOutputFolder = fullfile(dbEntry.resultsSavePath, 'M0', '2017-10-13', '4');
+            testCase.verifyTrue(exist(fullfile(dbEntry.resultsSavePath, 'M0'), 'dir') ~= 0);
+            testCase.verifyTrue(exist(fullfile(dbEntry.resultsSavePath, 'M0', '2017-10-13'), 'dir') ~= 0);
+            testCase.verifyTrue(exist(trueOutputFolder, 'dir') ~= 0);
+
+            % check results files are in place
+            testCase.verifyTrue(exist(fullfile(trueOutputFolder, 'F_M0_2017-10-13_plane1.mat'), 'file') ~= 0);
+            testCase.verifyTrue(exist(fullfile(trueOutputFolder, 'regops_M0_2017-10-13.mat'), 'file') ~= 0);
+
+            % delete files
+            rmdir(dbEntry.resultsSavePath, 's');
+            rmdir(dbEntry.RegFileBinLocation, 's');
+            delete(dbEntry.temp_tiff);
+        end
+
+        function emptyRequiredFields(testCase)
+            sm = CortexLabStorageManager(testCase.Options);
+
+            dbEntry.mouseName = 'M0';
+            dbEntry.date = '2017-10-13';
+            dbEntry.experiments = 4;
+            dbEntry.regFilePath = [];
+            dbEntry.rootStorage = testCase.DataFolder;
+
+            testCase.verifyError(@()sm.addEntry(dbEntry), 'Suite2P:incompleteDb');
+        end
+
+        function missingFields(testCase)
+            sm = CortexLabStorageManager(testCase.Options);
+
+            dbEntry.mouseName = 'M0';
+            dbEntry.date = '2017-10-13';
+            dbEntry.experiments = 4;
+            dbEntry.rootStorage = testCase.DataFolder;
+
+            testCase.verifyError(@()sm.addEntry(dbEntry), 'Suite2P:incompleteDb');
+        end
+
+        function multipleMouseNames(testCase)
+            sm = CortexLabStorageManager(testCase.Options);
+
+            dbEntry.mouseName    = {'MK020', 'M150416_MK020'};
+            dbEntry.date          = {'2015-07-30', '2015-07-30'};
+            dbEntry.experiments         = {[2010 2107], [1 2 3]};
+            dbEntry.diameter      = 12;
+            % empty means the folder with data
+            dbEntry.resultsSavePath = [];
+            dbEntry.rootStorage = fullfile(testCase.DataFolder, 'multiMouse');
+            dbEntry.regFilePath = fullfile(dbEntry.rootStorage, 'regFilePath');
+
+            %% prepare files
+            mk20_2010 = fullfile(testCase.DataFolder, 'multiMouse', 'MK020', '2015-07-30', '2010');
+            mk20_2107 = fullfile(testCase.DataFolder, 'multiMouse', 'MK020', '2015-07-30', '2107');
+            mkdir(mk20_2010);
+            mkdir(mk20_2107);
+
+            m_1 = fullfile(testCase.DataFolder, 'multiMouse', 'M150416_MK020', '2015-07-30', '1');
+            m_2 = fullfile(testCase.DataFolder, 'multiMouse', 'M150416_MK020', '2015-07-30', '2');
+            m_3 = fullfile(testCase.DataFolder, 'multiMouse', 'M150416_MK020', '2015-07-30', '3');
+            mkdir(m_1);
+            mkdir(m_2);
+            mkdir(m_3);
+
+            sourceFolder = fullfile(testCase.DataFolder, 'M0', '2017-10-13', '4');
+            copyfile(fullfile(sourceFolder, '*.tif'), mk20_2010);
+
+            copyfile(fullfile(sourceFolder, '*1.tif'), mk20_2107);
+            copyfile(fullfile(sourceFolder, '*4.tif'), mk20_2107);
+
+            copyfile(fullfile(sourceFolder, '*2.tif'), m_1);
+            copyfile(fullfile(sourceFolder, '*3.tif'), m_1);
+            copyfile(fullfile(sourceFolder, '*4.tif'), m_1);
+
+            copyfile(fullfile(sourceFolder, '*4.tif'), m_2);
+
+            copyfile(fullfile(sourceFolder, '*4.tif'), m_3);
+            copyfile(fullfile(sourceFolder, '*5.tif'), m_3);
+            copyfile(fullfile(sourceFolder, '*1.tif'), m_3);
+            oneFile = dir(fullfile(m_3, '*5.tif'));
+            movefile(fullfile(m_3, oneFile(1).name), fullfile(m_3, 'one_tiff.tiff'));
+
+            %% run the pipeline
+            sm.addEntry(dbEntry);
+            testCase.verifyEqual(sm.getNumEntries(), 1);
+
+            sm.selectEntry(1);
+            run_pipeline(sm);
+            add_deconvolution(sm);
+
+            % now let's check that we have files in proper places
+            binFile = 'MK020_2015-07-30_2010_2107_1_2_3_plane1.bin';
+            binExist = exist(fullfile(dbEntry.regFilePath, binFile), 'file') ~= 0;
+            testCase.verifyTrue(binExist);
+
+            resFolder = fullfile(dbEntry.rootStorage, dbEntry.mouseName{1}, dbEntry.date{1}, '2010_2107_1_2_3');
+            resultsFolderExist = exist(resFolder, 'dir') ~= 0;
+            testCase.verifyTrue(resultsFolderExist);
+
+            % check results files are in place
+            testCase.verifyTrue(exist(fullfile(resFolder, 'F_MK020_2015-07-30_plane1.mat'), 'file') ~= 0);
+            testCase.verifyTrue(exist(fullfile(resFolder, 'regops_MK020_2015-07-30.mat'), 'file') ~= 0);
+
+            % delete files
+            rmdir(dbEntry.rootStorage, 's');
+        end
+
+        function datasetWithoutFolderStructure(testCase)
+            sm = CortexLabStorageManager(testCase.Options);
+
+            dbEntry.mouseName = 'not_important';
+            dbEntry.date = '2016';
+            dbEntry.experiments = [];
+            dbEntry.diameter = 12;
+            dbEntry.rootStorage = fullfile(testCase.DataFolder, 'M0', '2017-10-13', '4');
+            dbEntry.resultsSavePath = fullfile(testCase.DataFolder, 'results');
+            dbEntry.regFilePath = fullfile(dbEntry.resultsSavePath, 'regFilePath');
+
+            sm.addEntry(dbEntry);
+
+            sm.selectEntry(1);
+            run_pipeline(sm);
+            add_deconvolution(sm);
+
+            testCase.verifyTrue(exist(dbEntry.regFilePath, 'dir') ~= 0);
+            binFile = dir(fullfile(dbEntry.regFilePath, 'not_important_2016__plane1.bin'));
+            testCase.verifyTrue(~isempty(binFile));
+
+            testCase.verifyTrue(exist(fullfile(dbEntry.resultsSavePath, ...
+                dbEntry.mouseName, dbEntry.date, 'F_not_important_2016_plane1.mat'),...
+                'file') ~= 0);
+
+            testCase.verifyTrue(exist(fullfile(dbEntry.resultsSavePath, ...
+                dbEntry.mouseName, dbEntry.date, 'regops_not_important_2016.mat'),...
+                'file') ~= 0);
+
+            rmdir(dbEntry.resultsSavePath, 's');
+        end
+    end
+
+    methods (Static=true)
+        function options = getDefaultOptions()
+            options.useGPU = gpuDeviceCount > 0;
+            options.fig = false;
+            options.readTiffHeader = false;
+            options.DeleteBin = false;
+
+            % registration options
+            options.doRegistration = true;
+            options.showTargetRegistration = true;
+            options.PhaseCorrelation = true;
+            options.SubPixel = Inf;
+            options.NimgFirstRegistration = 500;
+            options.dobidi = true;
+
+            % cell detection options
+            options.ShowCellMap = true;
+            options.sig = 0.5;
+            options.nSVDforROI = 1000;
+            options.NavgFramesSVD = 5000;
+            options.signalExtration = 'surround';
+
+            % neuropil options
+            options.innerNeuropil = 1;
+            options.outerNeuropil = Inf;
+            if isinf(options.outerNeuropil)
+                options.minNeuropilPixels = 400;
+                options.ratioNeuropil = 5;
+            end
+
+            % spike deconvolution and neuropil subtraction options
+            options.imageRate = 7;
+            options.sensorTau = 2;
+            options.maxNeurop = 1;
+
+            % red channel options
+            options.redthres = 1.5;
+            options.redmax = 1;
+        end
+    end
+end
+

--- a/tests/sendRequest.m
+++ b/tests/sendRequest.m
@@ -1,0 +1,91 @@
+% Send HTTP request, get response and additional information in retInfos.
+function [response, retInfos, history] = sendRequest(uri, request)
+
+% uri: matlab.net.URI
+% request: matlab.net.http.RequestMessage
+% response: matlab.net.http.ResponseMessage
+
+% matlab.net.http.HTTPOptions persists across requests to reuse  previous
+% Credentials in it for subsequent authentications
+persistent options 
+
+% infos is a containers.Map object where: 
+%    key is uri.Host; 
+%    value is "info" struct containing:
+%        cookies: vector of matlab.net.http.Cookie or empty
+%        uri: target matlab.net.URI if redirect, or empty
+persistent infos
+
+if isempty(options)
+    options = matlab.net.http.HTTPOptions('ConnectTimeout',20);
+end
+
+if isempty(infos)
+    infos = containers.Map;
+end
+host = string(uri.Host); % get Host from URI
+try
+    % get info struct for host in map
+    info = infos(char(host));
+    if ~isempty(info.uri)
+        % If it has a uri field, it means a redirect previously
+        % took place, so replace requested URI with redirect URI.
+        uri = info.uri;
+    end
+    if ~isempty(info.cookies)
+        % If it has cookies, it means we previously received cookies from this host.
+        % Add Cookie header field containing all of them.
+        request = request.addFields(matlab.net.http.field.CookieField(info.cookies));
+    end
+catch
+    % no previous redirect or cookies for this host
+    info = [];
+end
+
+% Send request and get response and history of transaction.
+[response, ~, history] = request.send(uri, options);
+if response.StatusCode ~= matlab.net.http.StatusCode.OK
+    return
+end
+
+% Get the Set-Cookie header fields from response message in
+% each history record and save them in the map.
+arrayfun(@addCookies, history)
+
+% If the last URI in the history is different from the URI sent in the original 
+% request, then this was a redirect. Save the new target URI in the host info struct.
+targetURI = history(end).URI;
+if ~isequal(targetURI, uri)
+    if isempty(info)
+        % no previous info for this host in map, create new one
+        infos(char(host)) = struct('cookies',[],'uri',targetURI);
+    else
+        % change URI in info for this host and put it back in map
+        info.uri = targetURI;
+        infos(char(host)) = info;
+    end
+end
+retInfos = infos;
+
+    function addCookies(record)
+        % Add cookies in Response message in history record
+        % to the map entry for the host to which the request was directed.
+        %
+        ahost = record.URI.Host; % the host the request was sent to
+        cookieFields = record.Response.getFields('Set-Cookie');
+        if isempty(cookieFields)
+            return
+        end
+        cookieData = cookieFields.convert(); % get array of Set-Cookie structs
+        cookies = [cookieData.Cookie]; % get array of Cookies from all structs
+        try
+            % If info for this host was already in the map, add its cookies to it.
+            ainfo = infos(ahost);
+            ainfo.cookies = [ainfo.cookies cookies];
+            infos(char(ahost)) = ainfo;
+        catch
+            % Not yet in map, so add new info struct.
+            infos(char(ahost)) = struct('cookies',cookies,'uri',[]);
+        end
+    end
+end

--- a/tiffTools/loadFramesBuff.m
+++ b/tiffTools/loadFramesBuff.m
@@ -5,64 +5,62 @@ function [frames, headers] = loadFramesBuff(tiff, firstIdx, lastIdx, stride, tem
 %   or an already open Tiff object. Optionallly FIRST, LAST and STRIDE
 %   specify the range of frame indices to load.
 
-if nargin>4 && ~isempty(temp_file)
-    if ~isequal(tiff, temp_file) % do not copy if already copied
-        % in case copying fails (server hangs)
-        iscopied = 0;
-        firstfail = 1;
-        while ~iscopied
-            try       
-                copyfile(tiff,temp_file);
-                iscopied = 1;
-                if ~firstfail
-                    fprintf('  succeeded!\n');
+    if nargin>4 && ~isempty(temp_file)
+        if ~isequal(tiff, temp_file) % do not copy if already copied
+            % in case copying fails (server hangs)
+            iscopied = 0;
+            firstfail = 1;
+            while ~iscopied
+                try
+                    copyfile(tiff,temp_file);
+                    iscopied = 1;
+                    if ~firstfail
+                        fprintf('  succeeded!\n');
+                    end
+                catch
+                    if firstfail
+                        fprintf('copy tiff failed, retrying...');
+                    end
+                    firstfail = 0;
+                    pause(10);
                 end
-            catch
-                if firstfail
-                    fprintf('copy tiff failed, retrying...');
-                end
-                firstfail = 0;
-                pause(10);
             end
+            tiff = temp_file;
         end
-        tiff = temp_file;
+        info = imfinfo(temp_file); % get info after copying
+        if isnan(lastIdx)
+            lastIdx = length(info); % get number of frames
+        end
     end
-    info = imfinfo(temp_file); % get info after copying
-    if isnan(lastIdx)
-        lastIdx = length(info); % get number of frames
+
+    % initChars = overfprintf(0, 'Loading TIFF frame ');
+    warning('off', 'MATLAB:imagesci:tiffmexutils:libtiffWarning');
+
+    warningsBackOn = onCleanup(@() warning('on', 'MATLAB:imagesci:tiffmexutils:libtiffWarning'));
+
+    if ischar(tiff) || isstring(tiff)
+        tiff = Tiff(tiff, 'r');
+        closeTiff = onCleanup(@() close(tiff));
     end
-end
 
-% initChars = overfprintf(0, 'Loading TIFF frame ');
-warning('off', 'MATLAB:imagesci:tiffmexutils:libtiffWarning');
+    if nargin < 2 || isempty(firstIdx)
+        firstIdx = 1;
+    end
 
-warningsBackOn = onCleanup(...
-    @() warning('on', 'MATLAB:imagesci:tiffmexutils:libtiffWarning'));
+    if nargin < 3 || isempty(lastIdx)
+        lastIdx = nFramesTiff(tiff);
+    end
 
-if ischar(tiff)
-    tiff = Tiff(tiff, 'r');
-    closeTiff = onCleanup(@() close(tiff));
-end
+    if nargin < 4 || isempty(stride)
+        stride = 1;
+    end
 
-if nargin < 2 || isempty(firstIdx)
-    firstIdx = 1;
-end
+    if nargout > 1
+        loadHeaders = true;
+    else
+        loadHeaders = false;
+    end
 
-if nargin < 3 || isempty(lastIdx)
-    lastIdx = nFramesTiff(tiff);
-end
-
-if nargin < 4 || isempty(stride)
-    stride = 1;
-end
-
-if nargout > 1
-    loadHeaders = true;
-else
-    loadHeaders = false;
-end
-
-if true %nargin <=4  %if the file was not copied locally use Tiff library
     w = tiff.getTag('ImageWidth');
     h = tiff.getTag('ImageLength');
     dataClass = class(read(tiff));
@@ -71,76 +69,23 @@ if true %nargin <=4  %if the file was not copied locally use Tiff library
     if loadHeaders
         headers = cell(1, nFrames);
     end
-    
-    nMsgChars = 0;
+
     setDirectory(tiff, firstIdx);
     for t = 1:nFrames
-        if mod(t, 100) == 0
-            %nMsgChars = overfprintf(nMsgChars, '%i/%i', t, nFrames);
-        end
-        
-        
-        frames(:,:,t) = read(tiff);
-        
+        frames(:, :, t) = read(tiff);
+
         if loadHeaders
-            headerNames = tiff.getTagNames;
             headers{t} = getTag(tiff, 'ImageDescription');
             try
                 headers{t} = [headers{t} getTag(tiff,'Software')];
             catch
             end
         end
-        
+
         if t < nFrames
             for i = 1:stride
                 nextDirectory(tiff);
             end
         end
     end
-    %overfprintf(initChars + nMsgChars, '');
-else % if the file is local (and on SSD) this way of reading works much faster
-    info = imfinfo(temp_file);
-    offset = info(1).Offset;
-    w = info(1).Width;
-    h = info(1).Height;
-    dataClass = 'int16'; % this is true for our ScanImage recordings, 
-    % it is possible to use info.BitDepth to try and figure out nBytesPerSample
-    
-    % MK: using memmapfile here, but just reading as a binary file might be
-    % faster, worth trying
-    m = memmapfile(temp_file, 'Format', dataClass, 'Offset', offset);
-    data = m.Data;
-%     clear m;
-    nPixels = w*h;
-    frameIdx = firstIdx:stride:lastIdx;
-    data = reshape(data, [], length(info));
-    nSamples = size(data, 1); % number of values in each frame related vector
-    % the images are the last nPixels values of this vector
-    % here we assume all the headers occupy the same number of bytes,
-    % this is true for ScanImage recordings. info.Offset is a useful field
-    % otherwise.
-    frames = data(nSamples-nPixels+1:nSamples, frameIdx);
-    frames = reshape(frames, w, h, []);
-    frames = permute(frames, [2 1 3]);
-    if loadHeaders
-        headers = {info(frameIdx).ImageDescription};
-    end
 end
-
-
-end
-
-
-%%
-%
-% figure
-% for i=1:3:nFrames
-%     subplot(1, 3, 1)
-%     imagesc(frames(:,:,i));
-%     subplot(1, 3, 2);
-%     imagesc(data(:,:,i));
-%     subplot(1, 3, 3);
-%     imagesc(frames(:,:,i)-data(:,:,i));
-%     drawnow;
-% end
-

--- a/tiffTools/nFrames.m
+++ b/tiffTools/nFrames.m
@@ -1,25 +1,39 @@
-function n = nFrames(tiff)
-%nFrames find the number of frames in the Tiff
+% Find the number of frames in a tiff file
+%
+% This function reports number of frames in a tiff file by
+% jumping over seekInterval frames until the end of the file.
+% This is in general faster than Matlab's imfinfo function.
+%
+%  USAGE
+%   n = nFrames(tiff, seekInterval)
+%   tiff            Path to tiff file or a handler of an already opened file.
+%   seekInterval    Optional number of frames to jump over.
+%                   Default is 1000.
+%   n               Number of frames
+%
+function n = nFrames(tiff, seekInterval)
+    if nargin < 2
+        seekInterval = 1000;
+    end
+    %keep guessing until we seek too far
+    guess = seekInterval;
+    overSeeked = false;
+    n = 0;
 
-%keep guessing until we seek too far
-guess = 1000;
-overSeeked = false;
+    if ischar(tiff) || isstring(tiff)
+        tiff = Tiff(tiff, 'r');
+        closeTiff = onCleanup(@() close(tiff));
+    end
 
-if ischar(tiff)
-  tiff = Tiff(tiff, 'r');
-  closeTiff = onCleanup(@() close(tiff));
-end
-
-while ~overSeeked
-  try
-    tiff.setDirectory(guess);
-    guess = 2*guess; %double the guess
-  catch ex
-    overSeeked = true; %we tried to seek past the last directory
-  end
-end
-%when overseeking occurs, the current directory/frame will be the last one
-n = tiff.currentDirectory;
-
+    while ~overSeeked
+      try
+        tiff.setDirectory(guess);
+        guess = 2*guess; %double the guess
+      catch ex
+        overSeeked = true; %we tried to seek past the last directory
+      end
+    end
+    %when overseeking occurs, the current directory/frame will be the last one
+    n = tiff.currentDirectory;
 end
 

--- a/tiffTools/nFramesTiff.m
+++ b/tiffTools/nFramesTiff.m
@@ -1,25 +1,6 @@
 function n = nFramesTiff(tiff)
 %nFrames find the number of frames in the Tiff
 
-%keep guessing until we seek too far
-guess = 2001;
-overSeeked = false;
-
-if ischar(tiff)
-  tiff = Tiff(tiff, 'r');
-  closeTiff = onCleanup(@() close(tiff));
-end
-
-while ~overSeeked
-  try
-    tiff.setDirectory(guess);
-    guess = 2*guess; %double the guess
-  catch ex
-    overSeeked = true; %we tried to seek past the last directory
-  end
-end
-%when overseeking occurs, the current directory/frame will be the last one
-n = tiff.currentDirectory;
-
+n = nFrames(tiff, 2001);
 end
 

--- a/utils/copyBinFile.m
+++ b/utils/copyBinFile.m
@@ -1,28 +1,23 @@
-function copyBinFile(ops1)
+function copyBinFile(ops1, sm)
+    for i = 1:size(ops1, 1)
+        for j = 1:size(ops1, 2)
+            fid = fopen(ops1{i, j}.RegFile, 'r');
 
-fid    = cell(size(ops1));
-for i = 1:size(ops1,1)
-    for j = 1:size(ops1,2)
-        fid{i,j}           = fopen(ops1{i,j}.RegFile, 'r');
-        folder = fullfile(ops1{i,j}.RegFileBinLocation, ops1{i,j}.mouse_name, ...
-            ops1{i,j}.date, ops1{i,j}.CharSubDirs);
-        if ~exist(folder, 'dir')
-            mkdir(folder)
-        end
-        fidCopy = fopen(fullfile(folder, ...
-            sprintf('%s_%s_%s_plane%d.bin', ops1{i,j}.mouse_name, ops1{i,j}.date, ...
-            ops1{i,j}.CharSubDirs, i)), 'w');
-        sz = ops1{i,j}.Lx * ops1{i,j}.Ly;
-        parts = ceil(sum(ops1{i,j}.Nframes) / 2000);
-        for p = 1:parts
-            toRead = 2000;
-            if p == parts
-                toRead = sum(ops1{i,j}.Nframes) - 2000 * (parts-1);
+            fileName = sm.registrationFileOnSlowStorage(i);
+            fidCopy = fopen(fileName, 'w');
+
+            sz = ops1{i,j}.Lx * ops1{i,j}.Ly;
+            parts = ceil(sum(ops1{i, j}.Nframes) / 2000);
+            for p = 1:parts
+                toRead = 2000;
+                if p == parts
+                    toRead = sum(ops1{i,j}.Nframes) - 2000 * (parts-1);
+                end
+                data = fread(fid,  sz*toRead, '*int16');
+                fwrite(fidCopy, data, class(data));
             end
-            data = fread(fid{i,j},  sz*toRead, '*int16');
-            fwrite(fidCopy, data, class(data));
+            fclose(fidCopy);
+            fclose(fid);
         end
-        fclose(fidCopy);
-        fclose(fid{i,j});
     end
 end

--- a/utils/getOr.m
+++ b/utils/getOr.m
@@ -13,7 +13,7 @@ end
 
 fieldExists = isfield(s, field);
 if any(fieldExists)
-  if iscellstr(field)
+  if iscellstr(field) || isstring(field)
     v = s.(field{find(fieldExists, 1)});
   else
     v = s.(field);


### PR DESCRIPTION
Hi!
This series of commits bring support of different kinds of folder structure to Suite2P. The intention is to decouple folder structure (file organization) from the code. This is done through an interface `BasicStorageManager`. It is a class that does several things: it handles db entries, it knows about file paths, it provides options.

Suite2P has a very tight coupling between db and options. I tried not to ruin it completely and options inside storage manage can be viewed as former `ops0` variable.

The interface has a number of abstract methods and this is how folder structure is decoupled. Code that interacts with the interface knows that a particular method returns a full file path. It doesn't need to know anything else. The implementation of the interface will know a particular folder structure and will construct the appropriate file path. I include one implementation, called `CortexLabStorageManager`, which can be used as default and it implements folder structure as follows:

```
\RootStorage\mouse_name\session\block*.tif(f)
```

Note, however, that the interface has a different way of providing information about files. There is a db entry, which describes experiments that you would like to be processed. Each db entry may consist of one or several *partitions*. In former Suite2P code, partition corresponds to sub folders (typically different experiments). Ideally, code that uses the interface should not care about partitions and may get all files from all partitions sequentially. This is similar to how Matlab defines [Datastore](https://se.mathworks.com/help/matlab/import_export/what-is-a-datastore.html), in particular [FileDatastore](https://se.mathworks.com/help/matlab/ref/matlab.io.datastore.filedatastore.html). Note that it is still possible to obtain information about partitions.

Whenever some code needs a file path/folder, it should ask storage manager for it. For example, a call to `fileName = sm.getFileForPlane('f', 1)` will return a full file path for `f` results file that corresponds to the first plane. After that, the code may proceed with working with the file name, e.g. `fid = fopen(fileName, 'w');`.

Attached is [an UML diagram](https://user-images.githubusercontent.com/191278/43975989-98592898-9cdf-11e8-90b5-70f2c0c9d403.png) of the interface, where symbols before each member name are
```
+         Public
-         Private
#         Protected
```
and other properties are:
```
italic     abstract
```

You may see that the interface implements basic operations with db entries within itself.

**Important!** With new storage manager, variables for file paths and folders have moved from options to db entries. Moreover, if desired, every db entry may have a different `rootStorage`, `RegFileBinLocation`, e.t.c.

An implementation class `CortexLabStorageManager` is provided as well. I tried to write this class so that it is backwards compatible with former `db` and `ops0` variables. There is also a static method `convertDbToStorageManager`, which converts former `db` to new representation.

I've also added unit tests for `CortexLabStorageManager`. They are found in file `CortexLabStorageManagerTest.m` in folder `tests`. By default, test suite automatically downloads 5 tiff files from a shared dataset (provided by Suite2P and stored on Google Drive). One can, however, download files manually and point the test suite to it either through an environment variable or by modifying the code of `CortexLabStorageManagerTest` directly.

## Limitations

I focused on a standard non-GUI pipeline only. This means that there files that use storage manager and there are still a lot of files inside Suite2P, which do not. It is hard for me to judge if all files should be modified. From my perspective there is a lot of code which seams to be dead. I call a function or a file dead if there are no references to that function/file from any other file in the toolbox.

The part of the pipeline that deals with red channel (i.e. `run_REDaddon_sourcery`) is not yet implemented to work with storage manager. I shall get some test files next week and fix this.

## Final words

I hope that you will find this patch useful. Feel free to comment or ask any questions. We would really love to see this merged in the main code base as we use different folder structure and every time there is a new commit upstream we have to go through a tedious process of manual merging.