### PR TITLE
Add description to nFrames function and omit duplicate code

### DIFF
--- a/tiffTools/nFrames.m
+++ b/tiffTools/nFrames.m
@@ -1,25 +1,39 @@
-function n = nFrames(tiff)
-%nFrames find the number of frames in the Tiff
+% Find the number of frames in a tiff file
+%
+% This function reports number of frames in a tiff file by
+% jumping over seekInterval frames until the end of the file.
+% This is in general faster than Matlab's imfinfo function.
+%
+%  USAGE
+%   n = nFrames(tiff, seekInterval)
+%   tiff            Path to tiff file or a handler of an already opened file.
+%   seekInterval    Optional number of frames to jump over.
+%                   Default is 1000.
+%   n               Number of frames
+%
+function n = nFrames(tiff, seekInterval)
+    if nargin < 2
+        seekInterval = 1000;
+    end
+    %keep guessing until we seek too far
+    guess = seekInterval;
+    overSeeked = false;
+    n = 0;
 
-%keep guessing until we seek too far
-guess = 1000;
-overSeeked = false;
+    if ischar(tiff) || isstring(tiff)
+        tiff = Tiff(tiff, 'r');
+        closeTiff = onCleanup(@() close(tiff));
+    end
 
-if ischar(tiff)
-  tiff = Tiff(tiff, 'r');
-  closeTiff = onCleanup(@() close(tiff));
-end
-
-while ~overSeeked
-  try
-    tiff.setDirectory(guess);
-    guess = 2*guess; %double the guess
-  catch ex
-    overSeeked = true; %we tried to seek past the last directory
-  end
-end
-%when overseeking occurs, the current directory/frame will be the last one
-n = tiff.currentDirectory;
-
+    while ~overSeeked
+      try
+        tiff.setDirectory(guess);
+        guess = 2*guess; %double the guess
+      catch ex
+        overSeeked = true; %we tried to seek past the last directory
+      end
+    end
+    %when overseeking occurs, the current directory/frame will be the last one
+    n = tiff.currentDirectory;
 end
 

--- a/tiffTools/nFramesTiff.m
+++ b/tiffTools/nFramesTiff.m
@@ -1,25 +1,6 @@
 function n = nFramesTiff(tiff)
 %nFrames find the number of frames in the Tiff
 
-%keep guessing until we seek too far
-guess = 2001;
-overSeeked = false;
-
-if ischar(tiff)
-  tiff = Tiff(tiff, 'r');
-  closeTiff = onCleanup(@() close(tiff));
-end
-
-while ~overSeeked
-  try
-    tiff.setDirectory(guess);
-    guess = 2*guess; %double the guess
-  catch ex
-    overSeeked = true; %we tried to seek past the last directory
-  end
-end
-%when overseeking occurs, the current directory/frame will be the last one
-n = tiff.currentDirectory;
-
+n = nFrames(tiff, 2001);
 end
 


### PR DESCRIPTION
nFrames and nFramesTiff differ only in the number of frames being skipped during file reading. Add an optional input argument to nFrames which specifies how many frames to skip. nFramesTiff is just a wrapper around nFrames with a pre-defined number of frames to skip.
This fix has no braking changes.